### PR TITLE
mountpoint: fix two clippy warnings on Windows

### DIFF
--- a/src/uu/mountpoint/src/mountpoint.rs
+++ b/src/uu/mountpoint/src/mountpoint.rs
@@ -6,6 +6,7 @@
 use clap::Arg;
 use clap::{crate_version, Command};
 use std::env;
+#[cfg(not(windows))]
 use std::fs;
 #[cfg(not(windows))]
 use std::os::unix::fs::MetadataExt;
@@ -54,7 +55,7 @@ fn is_mountpoint(path: &str) -> bool {
 
 // TODO: implement for windows
 #[cfg(windows)]
-fn is_mountpoint(path: &str) -> bool {
+fn is_mountpoint(_path: &str) -> bool {
     false
 }
 

--- a/tests/by-util/test_mountpoint.rs
+++ b/tests/by-util/test_mountpoint.rs
@@ -4,9 +4,7 @@
 // file that was distributed with this source code.
 // spell-checker:ignore (words) symdir somefakedir
 
-use std::path::PathBuf;
-
-use crate::common::util::{TestScenario, UCommand};
+use crate::common::util::TestScenario;
 
 #[test]
 fn test_invalid_arg() {


### PR DESCRIPTION
This PR fixes two clippy warnings on Windows about an unused import and an unused variable. Combined with https://github.com/uutils/util-linux/pull/27 it should make the "cargo clippy" tests in the CI pass.