### PR TITLE
lscpu: make `--help` & `--version` work

### DIFF
--- a/src/uu/lscpu/src/lscpu.rs
+++ b/src/uu/lscpu/src/lscpu.rs
@@ -13,7 +13,8 @@ const ABOUT: &str = help_about!("lscpu.md");
 const USAGE: &str = help_usage!("lscpu.md");
 
 #[uucore::main]
-pub fn uumain(_args: impl uucore::Args) -> UResult<()> {
+pub fn uumain(args: impl uucore::Args) -> UResult<()> {
+    let _matches: clap::ArgMatches = uu_app().try_get_matches_from(args)?;
     let system = System::new_all();
     let _cpu = system.global_cpu_info();
 


### PR DESCRIPTION
This PR makes clap's `-h`/`--help` and `-V`/`--version` functionality work.