### PR TITLE
rev: fix two pedantic clippy warnings

### DIFF
--- a/src/uu/rev/src/rev.rs
+++ b/src/uu/rev/src/rev.rs
@@ -24,24 +24,22 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     let zero = matches.get_flag(options::ZERO);
 
     let sep = if zero { b'\0' } else { b'\n' };
-    match files {
-        Some(files) => {
-            for path in files {
-                let Ok(file) = std::fs::File::open(path) else {
-                    uucore::error::set_exit_code(1);
-                    uucore::show_error!("cannot open {path}: No such file or directory");
-                    continue;
-                };
-                if let Err(err) = rev_stream(file, sep) {
-                    uucore::error::set_exit_code(1);
-                    uucore::show_error!("cannot read {path}: {err}");
-                }
+
+    if let Some(files) = files {
+        for path in files {
+            let Ok(file) = std::fs::File::open(path) else {
+                uucore::error::set_exit_code(1);
+                uucore::show_error!("cannot open {path}: No such file or directory");
+                continue;
+            };
+            if let Err(err) = rev_stream(file, sep) {
+                uucore::error::set_exit_code(1);
+                uucore::show_error!("cannot read {path}: {err}");
             }
         }
-        None => {
-            let stdin = std::io::stdin().lock();
-            let _ = rev_stream(stdin, sep);
-        }
+    } else {
+        let stdin = std::io::stdin().lock();
+        let _ = rev_stream(stdin, sep);
     }
 
     Ok(())

--- a/src/uu/rev/src/rev.rs
+++ b/src/uu/rev/src/rev.rs
@@ -54,15 +54,15 @@ fn rev_stream(stream: impl Read, sep: u8) -> std::io::Result<()> {
     loop {
         buf.clear();
         stream.read_until(sep, &mut buf)?;
-        if buf.last().copied() != Some(sep) {
-            buf.reverse();
-            stdout.write_all(&buf)?;
-            break;
-        } else {
+        if buf.last().copied() == Some(sep) {
             buf.pop();
             buf.reverse();
             buf.push(sep);
             stdout.write_all(&buf)?;
+        } else {
+            buf.reverse();
+            stdout.write_all(&buf)?;
+            break;
         }
     }
     Ok(())


### PR DESCRIPTION
This PR fixes two warnings from `clippy::pedantic`: 

* it uses `==` instead of `!=` in a condition
* it replaces a `match` with `if let`
