### PR TITLE
tests: fix "unused import" warnings on Windows

### DIFF
--- a/tests/by-util/test_last.rs
+++ b/tests/by-util/test_last.rs
@@ -9,8 +9,6 @@ use crate::common::util::TestScenario;
 
 #[cfg(unix)]
 use regex::Regex;
-use std::fs;
-use std::io::Write;
 
 #[test]
 #[cfg(unix)]
@@ -95,19 +93,18 @@ fn test_timestamp_format_iso() {
 #[test]
 #[cfg(unix)]
 fn test_short_invalid_utmp_file() {
-    let filepath = "/tmp/testfile";
-    let testfile = fs::File::create(filepath);
+    let (at, mut ucmd) = at_and_ucmd!();
+    let file = "testfile";
     // Random bytes
-    let data: Vec<u8> = vec![
+    let data = [
         4, 5, 6, 16, 8, 13, 2, 12, 5, 3, 11, 5, 1, 13, 1, 1, 0, 9, 5, 5, 2, 8, 4,
     ];
-    let _ = testfile.unwrap().write_all(&data);
+    at.write_bytes(file, &data);
 
     let regex = Regex::new(r"\n\S*\sbegins\s*(Mon|Tue|Wed|Thu|Fri|Sat|Sun)\s*(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s*[0-9][0-9]?\s*[0-9][0-9]:[0-9][0-9]:[0-9][0-9]\s*[0-9]*")
             .unwrap();
 
-    new_ucmd!()
-        .arg(format!("--file={filepath}"))
+    ucmd.arg(format!("--file={file}"))
         .succeeds()
         .stdout_matches(&regex);
 }

--- a/tests/by-util/test_last.rs
+++ b/tests/by-util/test_last.rs
@@ -4,8 +4,10 @@
 // file that was distributed with this source code.
 // spell-checker:ignore (words) symdir somefakedir
 
+#[cfg(unix)]
 use crate::common::util::TestScenario;
 
+#[cfg(unix)]
 use regex::Regex;
 use std::fs;
 use std::io::Write;

--- a/tests/by-util/test_setsid.rs
+++ b/tests/by-util/test_setsid.rs
@@ -161,7 +161,7 @@ mod unix {
 
 #[cfg(not(target_family = "unix"))]
 mod non_unix {
-    use crate::common::util::{TestScenario, UCommand};
+    use crate::common::util::TestScenario;
 
     #[test]
     fn unsupported_platforms() {


### PR DESCRIPTION
This PR fixes "unused import" warnings on Windows (see https://github.com/uutils/util-linux/actions/runs/11739829667/job/32705131920#step:4:231). Some warnings are fixed by adding `#[cfg(unix)]`, other warnings are fixed by rewriting a test to get rid of the imports.