### PR TITLE
dmesg: remove useless `format!` in test

### DIFF
--- a/tests/by-util/test_dmesg.rs
+++ b/tests/by-util/test_dmesg.rs
@@ -184,8 +184,6 @@ fn test_since_until_invalid_time() {
         new_ucmd!()
             .arg(format!("{option}=definitely-invalid"))
             .fails()
-            .stderr_only(format!(
-                "dmesg: invalid time value \"definitely-invalid\"\n"
-            ));
+            .stderr_only("dmesg: invalid time value \"definitely-invalid\"\n");
     }
 }


### PR DESCRIPTION
This PR removes a `format!` in a test to fix a warning from the [useless_format](https://rust-lang.github.io/rust-clippy/master/index.html#useless_format) lint.