### PR TITLE
Bump `rand` & adapt tests to its API changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,24 +287,13 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.13.3+wasi-0.2.2",
+ "wasi",
  "windows-targets 0.52.6",
 ]
 
@@ -559,7 +548,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -583,7 +572,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -664,19 +653,28 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "libc",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.0",
+ "zerocopy 0.8.14",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.0",
 ]
 
 [[package]]
@@ -684,8 +682,15 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rand_core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b08f3c9802962f7e1b25113931d94f43ed9725bebc59db9d0c3e9a23b67e15ff"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
+ "zerocopy 0.8.14",
 ]
 
 [[package]]
@@ -918,7 +923,7 @@ checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
 dependencies = [
  "cfg-if",
  "fastrand",
- "getrandom 0.3.1",
+ "getrandom",
  "once_cell",
  "rustix 0.38.39",
  "windows-sys 0.59.0",
@@ -1033,7 +1038,7 @@ dependencies = [
  "phf_codegen",
  "pretty_assertions",
  "procfs",
- "rand",
+ "rand 0.9.0",
  "regex",
  "rlimit",
  "tempfile",
@@ -1174,12 +1179,6 @@ name = "uuhelp_parser"
 version = "0.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cf4c8b31abfb5dc79940d6ca8000a1a6aa42f38711cdeaacb95850c69924cbc"
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi"
@@ -1519,7 +1518,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a367f292d93d4eab890745e75a778da40909cab4d6ff8173693812f79c4a2468"
+dependencies = [
+ "zerocopy-derive 0.8.14",
 ]
 
 [[package]]
@@ -1527,6 +1535,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.82",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3931cb58c62c13adec22e38686b559c86a30565e16ad6e8510a337cedc611e1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ linux-raw-sys = { version = "0.7.0", features = ["ioctl"] }
 nix = { version = "0.29", default-features = false }
 phf = "0.11.2"
 phf_codegen = "0.11.2"
-rand = { version = "0.8", features = ["small_rng"] }
+rand = { version = "0.9.0", features = ["small_rng"] }
 regex = "1.10.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.122"

--- a/tests/common/random.rs
+++ b/tests/common/random.rs
@@ -1,10 +1,10 @@
-// This file is part of the uutils coreutils package.
+// This file is part of the uutils util-linux package.
 //
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-use rand::distributions::{Distribution, Uniform};
-use rand::{thread_rng, Rng};
+use rand::distr::{Distribution, Uniform};
+use rand::{rng, Rng};
 
 /// Samples alphanumeric characters `[A-Za-z0-9]` including newline `\n`
 ///
@@ -38,7 +38,7 @@ impl AlphanumericNewline {
     where
         R: Rng + ?Sized,
     {
-        let idx = rng.gen_range(0..Self::CHARSET.len());
+        let idx = rng.random_range(0..Self::CHARSET.len());
         Self::CHARSET[idx]
     }
 }
@@ -80,7 +80,7 @@ impl RandomString {
     where
         D: Distribution<u8>,
     {
-        thread_rng()
+        rng()
             .sample_iter(dist)
             .take(length)
             .map(|b| b as char)
@@ -132,15 +132,15 @@ impl RandomString {
             return if num_delimiter > 0 {
                 String::from(delimiter as char)
             } else {
-                String::from(thread_rng().sample(&dist) as char)
+                String::from(rng().sample(&dist) as char)
             };
         }
 
         let samples = length - 1;
-        let mut result: Vec<u8> = thread_rng().sample_iter(&dist).take(samples).collect();
+        let mut result: Vec<u8> = rng().sample_iter(&dist).take(samples).collect();
 
         if num_delimiter == 0 {
-            result.push(thread_rng().sample(&dist));
+            result.push(rng().sample(&dist));
             return String::from_utf8(result).unwrap();
         }
 
@@ -150,9 +150,10 @@ impl RandomString {
             num_delimiter
         };
 
-        let between = Uniform::new(0, samples);
+        // safe to unwrap because samples is at least 1, thus high > low
+        let between = Uniform::new(0, samples).unwrap();
         for _ in 0..num_delimiter {
-            let mut pos = between.sample(&mut thread_rng());
+            let mut pos = between.sample(&mut rng());
             let turn = pos;
             while result[pos] == delimiter {
                 pos += 1;
@@ -169,7 +170,7 @@ impl RandomString {
         if end_with_delimiter {
             result.push(delimiter);
         } else {
-            result.push(thread_rng().sample(&dist));
+            result.push(rng().sample(&dist));
         }
 
         String::from_utf8(result).unwrap()
@@ -179,7 +180,7 @@ impl RandomString {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand::distributions::Alphanumeric;
+    use rand::distr::Alphanumeric;
 
     #[test]
     fn test_random_string_generate() {


### PR DESCRIPTION
This PR bumps `rand` from `0.8.5` to `0.9.0` and adapts `tests/common/random.rs` to the API changes.