### PR TITLE
lscpu: fix code formatting & remove sentence from help text

### DIFF
--- a/src/uu/lscpu/src/lscpu.rs
+++ b/src/uu/lscpu/src/lscpu.rs
@@ -56,7 +56,17 @@ pub fn uu_app() -> Command {
         .version(crate_version!())
         .about(ABOUT)
         .override_usage(format_usage(USAGE))
-        .infer_long_args(true).arg(Arg::new(options::HEX).short('x').long("hex").action(ArgAction::SetTrue).help("Use hexadecimal masks for CPU sets (for example 'ff'). The default is to print the
-        sets in list format (for example 0,1). Note that before version 2.30 the mask has been
-        printed with 0x prefix.").required(false))
+        .infer_long_args(true)
+        .arg(
+            Arg::new(options::HEX)
+                .short('x')
+                .long("hex")
+                .action(ArgAction::SetTrue)
+                .help(
+                    "Use hexadecimal masks for CPU sets (for example 'ff'). \
+                    The default is to print the sets in list format (for example 0,1). \
+                    Note that before version 2.30 the mask has been printed with 0x prefix.",
+                )
+                .required(false),
+        )
 }

--- a/src/uu/lscpu/src/lscpu.rs
+++ b/src/uu/lscpu/src/lscpu.rs
@@ -64,8 +64,7 @@ pub fn uu_app() -> Command {
                 .action(ArgAction::SetTrue)
                 .help(
                     "Use hexadecimal masks for CPU sets (for example 'ff'). \
-                    The default is to print the sets in list format (for example 0,1). \
-                    Note that before version 2.30 the mask has been printed with 0x prefix.",
+                    The default is to print the sets in list format (for example 0,1).",
                 )
                 .required(false),
         )


### PR DESCRIPTION
This PR fixes the code formatting because `fmt` stopped doing it due to a string that was too long. The PR also removes an irrelevant sentence from the help text.