### PR TITLE
lscpu: rename test function

### DIFF
--- a/tests/by-util/test_lscpu.rs
+++ b/tests/by-util/test_lscpu.rs
@@ -11,6 +11,6 @@ fn test_invalid_arg() {
 }
 
 #[test]
-fn test_lscpt_with_arg() {
+fn test_hex() {
     new_ucmd!().arg("--hex").succeeds().stdout_contains("0x");
 }


### PR DESCRIPTION
This PR renames a test function because the original name contains a typo and isn't very descriptive.