### PR TITLE
`lscpu`: Support extracting and outputting nested fields

### DIFF
--- a/src/uu/lscpu/src/lscpu.rs
+++ b/src/uu/lscpu/src/lscpu.rs
@@ -86,12 +86,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     let mut arch_info = CpuInfo::new("Architecture", &get_architecture(), None);
 
-    let contents = match fs::read_to_string("/proc/cpuinfo") {
-        // Early return if we can't read /proc/cpuinfo for whatever reason
-        // TODO: Should this return an non-zero exit code to user, or do we just ignore it and display whatever CPU info we could find?
-        Err(_) => return Ok(()),
-        Ok(contents) => contents,
-    };
+    // TODO: We just silently ignore failures to read `/proc/cpuinfo` currently and treat it as empty
+    // Perhaps a better solution should be put in place, but what?
+    let contents = fs::read_to_string("/proc/cpuinfo").unwrap_or_default();
 
     if let Some(addr_sizes) = find_cpuinfo_value(&contents, "address sizes") {
         arch_info.add_child(CpuInfo::new("Address sizes", &addr_sizes, None))

--- a/src/uu/lscpu/src/lscpu.rs
+++ b/src/uu/lscpu/src/lscpu.rs
@@ -78,11 +78,6 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     };
 
     let mut cpu_infos = CpuInfos::new();
-    cpu_infos.push(CpuInfo::new(
-        "CPU(s)",
-        &format!("{}", system.cpus().len()),
-        None,
-    ));
 
     let mut arch_info = CpuInfo::new("Architecture", &get_architecture(), None);
 
@@ -103,6 +98,11 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     }
 
     cpu_infos.push(arch_info);
+    cpu_infos.push(CpuInfo::new(
+        "CPU(s)",
+        &format!("{}", system.cpus().len()),
+        None,
+    ));
 
     // TODO: This is currently quite verbose and doesn't strictly respect the hierarchy of `/proc/cpuinfo` contents
     // ie. the file might contain multiple sections, each with their own vendor_id/model name etc. but right now
@@ -155,14 +155,6 @@ fn print_output(infos: CpuInfos, out_opts: OutputOptions) {
         cmp::max(own_width, max_child_width)
     }
 
-    // Used later to align all values to the same column
-    let max_field_width = infos
-        .lscpu
-        .iter()
-        .map(|info| get_max_field_width(info, 0))
-        .max()
-        .unwrap();
-
     fn print_entries(
         entries: &Vec<CpuInfo>,
         depth: usize,
@@ -182,6 +174,14 @@ fn print_output(infos: CpuInfos, out_opts: OutputOptions) {
             print_entries(&entry.children, depth + 1, max_field_width, _out_opts);
         }
     }
+
+    // Used to align all values to the same column
+    let max_field_width = infos
+        .lscpu
+        .iter()
+        .map(|info| get_max_field_width(info, 0))
+        .max()
+        .unwrap();
 
     print_entries(&infos.lscpu, 0, max_field_width, &out_opts);
 }

--- a/src/uu/lscpu/src/lscpu.rs
+++ b/src/uu/lscpu/src/lscpu.rs
@@ -94,6 +94,15 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         arch_info.add_child(CpuInfo::new("Address sizes", &addr_sizes, None))
     }
 
+    if let Ok(byte_order) = fs::read_to_string("/sys/kernel/cpu_byteorder") {
+        match byte_order.trim() {
+            "big" => arch_info.add_child(CpuInfo::new("Byte Order", "Big Endian", None)),
+            "little" => arch_info.add_child(CpuInfo::new("Byte Order", "Little Endian", None)),
+            _ => eprintln!("Unrecognised Byte Order: {}", byte_order)
+
+        }
+    }
+
     cpu_infos.push(arch_info);
 
     // TODO: This is currently quite verbose and doesn't strictly respect the hierarchy of `/proc/cpuinfo` contents

--- a/tests/by-util/test_lscpu.rs
+++ b/tests/by-util/test_lscpu.rs
@@ -17,12 +17,33 @@ fn test_hex() {
 }
 
 #[test]
+#[cfg(target_os = "linux")]
 fn test_json() {
-    new_ucmd!()
-        .arg("--json")
-        .succeeds()
-        // ensure some fields are there, non-exhausting
-        .stdout_contains("\"lscpu\": [")
+    let res = new_ucmd!().arg("--json").succeeds();
+
+    let stdout = res.no_stderr().stdout_str();
+    assert!(stdout.starts_with("{"));
+    assert!(stdout.ends_with("}\n"));
+
+    res.stdout_contains("\"lscpu\": [")
         .stdout_contains("\"field\": \"Architecture\"")
-        .stdout_contains("\"field\": \"CPU(s)\"");
+        .stdout_contains("\"field\": \"CPU(s)\"")
+        .stdout_contains("\"children\": [");
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_output() {
+    let res = new_ucmd!().succeeds();
+    let stdout = res.no_stderr().stdout_str();
+
+    // Non-exhaustive list of fields we expect
+    // This also checks that fields which should be indented, are indeed indented as excepted
+    assert!(stdout.contains("Architecture:"));
+    assert!(stdout.contains("\n  Address sizes:"));
+    assert!(stdout.contains("\n  Byte Order:"));
+    assert!(stdout.contains("\nCPU(s):"));
+    assert!(stdout.contains("\nVendor ID:"));
+    assert!(stdout.contains("\n  Model name:"));
+    assert!(stdout.contains("\n    CPU Family:"));
 }


### PR DESCRIPTION
`lscpu` should be capable of outputting nested information. When using human-readable output this is achieved simply using indentation, where as in JSON mode nested fields go under the `children` property.

### Core changes:
- Modified `CpuInfo` to be a recursive structure, allowing for nesting of entries through the `children` property.
- Moved output logic into its own function, adding support for printing out nested values, and ensuring the values on the right are aligned to the same column.
- Implemented a helper function for extracting arbitrary values from `/proc/cpuinfo`, using a dynamically constructed Regex.
- Added support for some basic fields like Vendor ID, CPU Family and Model, to illustrate how the aforementioned changes can be used in action.
- Added missing `-J` shorthand counterpart to the `--json` option.

### Output:
```
CPU(s):          16
Architecture:    x86_64
  Address sizes: 48 bits physical, 48 bits virtual
  Byte Order:    Little Endian
Vendor ID:       AuthenticAMD
  Model name:    AMD Ryzen 7 7700X 8-Core Processor
    CPU Family:  25
    Model:       97
```