### PR TITLE
Implement `chcpu`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -969,6 +969,7 @@ dependencies = [
  "tempfile",
  "textwrap",
  "uu_blockdev",
+ "uu_chcpu",
  "uu_ctrlaltdel",
  "uu_dmesg",
  "uu_fsfreeze",
@@ -992,6 +993,14 @@ dependencies = [
  "linux-raw-sys 0.9.2",
  "regex",
  "sysinfo",
+ "uucore",
+]
+
+[[package]]
+name = "uu_chcpu"
+version = "0.0.1"
+dependencies = [
+ "clap",
  "uucore",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ uudoc = []
 
 feat_common_core = [
   "blockdev",
+  "chcpu",
   "ctrlaltdel",
   "dmesg",
   "fsfreeze",
@@ -73,6 +74,7 @@ uucore = { workspace = true }
 
 #
 blockdev = { optional = true, version = "0.0.1", package = "uu_blockdev", path = "src/uu/blockdev" }
+chcpu = { optional = true, version = "0.0.1", package = "uu_chcpu", path = "src/uu/chcpu" }
 ctrlaltdel = { optional = true, version = "0.0.1", package = "uu_ctrlaltdel", path = "src/uu/ctrlaltdel" }
 dmesg = { optional = true, version = "0.0.1", package = "uu_dmesg", path = "src/uu/dmesg" }
 fsfreeze = { optional = true, version = "0.0.1", package = "uu_fsfreeze", path = "src/uu/fsfreeze" }

--- a/src/uu/chcpu/Cargo.toml
+++ b/src/uu/chcpu/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "uu_chcpu"
+version = "0.0.1"
+edition = "2021"
+
+[lib]
+path = "src/chcpu.rs"
+
+[[bin]]
+name = "chcpu"
+path = "src/main.rs"
+
+[dependencies]
+uucore = { workspace = true }
+clap = { workspace = true }

--- a/src/uu/chcpu/chcpu.md
+++ b/src/uu/chcpu/chcpu.md
@@ -1,0 +1,7 @@
+# chcpu
+
+```
+chcpu [OPTION]...
+```
+
+Configure CPUs in a multi-processor system.

--- a/src/uu/chcpu/src/chcpu.rs
+++ b/src/uu/chcpu/src/chcpu.rs
@@ -3,17 +3,118 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-use clap::{crate_version, Command};
-use uucore::error::UResult;
+use clap::{crate_version, Arg, ArgAction, ArgGroup, Command};
+use uucore::{error::UResult, format_usage, help_about, help_usage};
+
+fn enable_cpus(cpu_list: &str) {
+    println!("Enabling CPUs: {}", cpu_list)
+}
+
+fn disable_cpus(cpu_list: &str) {
+    println!("Disabling CPUs: {}", cpu_list)
+}
+
+fn configure_cpus(cpu_list: &str) {
+    println!("Configuring CPUs: {}", cpu_list)
+}
+
+fn deconfigure_cpus(cpu_list: &str) {
+    println!("Deconfiguring CPUs: {}", cpu_list)
+}
+
+fn set_dispatch_mode(mode: &str) {
+    println!("Setting dispatch mode to: {}", mode)
+}
 
 #[uucore::main]
-pub fn uumain(_args: impl uucore::Args) -> UResult<()> {
-    println!("chcpu: Hello world");
+pub fn uumain(args: impl uucore::Args) -> UResult<()> {
+    let matches = uu_app().try_get_matches_from(args)?;
+
+    if let Some(cpu_list) = matches.get_one::<String>(options::ENABLE) {
+        enable_cpus(cpu_list);
+    }
+
+    if let Some(cpu_list) = matches.get_one::<String>(options::DISABLE) {
+        disable_cpus(cpu_list);
+    }
+
+    if let Some(cpu_list) = matches.get_one::<String>(options::CONFIGURE) {
+        configure_cpus(cpu_list);
+    }
+
+    if let Some(cpu_list) = matches.get_one::<String>(options::DECONFIGURE) {
+        deconfigure_cpus(cpu_list);
+    }
+
+    if let Some(mode) = matches.get_one::<String>(options::DISPATCH) {
+        set_dispatch_mode(mode);
+    }
+
     Ok(())
 }
+
+mod options {
+    pub const ENABLE: &str = "enable";
+    pub const DISABLE: &str = "disable";
+    pub const CONFIGURE: &str = "configure";
+    pub const DECONFIGURE: &str = "deconfigure";
+    pub const DISPATCH: &str = "dispatch";
+}
+
+const ABOUT: &str = help_about!("chcpu.md");
+const USAGE: &str = help_usage!("chcpu.md");
 
 pub fn uu_app() -> Command {
     Command::new(uucore::util_name())
         .version(crate_version!())
+        .about(ABOUT)
+        .override_usage(format_usage(USAGE))
         .infer_long_args(true)
+        .arg(
+            Arg::new(options::ENABLE)
+                .short('e')
+                .long("enable")
+                .value_name("cpu-list")
+                .action(ArgAction::Set),
+        )
+        .arg(
+            Arg::new(options::DISABLE)
+                .short('d')
+                .long("disable")
+                .value_name("cpu-list")
+                .action(ArgAction::Set),
+        )
+        .arg(
+            Arg::new(options::CONFIGURE)
+                .short('c')
+                .long("configure")
+                .value_name("cpu-list")
+                .action(ArgAction::Set),
+        )
+        .arg(
+            Arg::new(options::DECONFIGURE)
+                .short('g')
+                .long("deconfigure")
+                .value_name("cpu-list")
+                .action(ArgAction::Set),
+        )
+        .arg(
+            Arg::new(options::DISPATCH)
+                .short('p')
+                .long("dispatch")
+                .value_name("mode")
+                .action(ArgAction::Set),
+        )
+        .group(
+            ArgGroup::new("action")
+                .args(vec![
+                    options::ENABLE,
+                    options::DISABLE,
+                    options::CONFIGURE,
+                    options::DECONFIGURE,
+                    options::DISPATCH,
+                ])
+                .multiple(false) // These 5 are mutually exclusive
+                .required(true),
+        )
 }

--- a/src/uu/chcpu/src/chcpu.rs
+++ b/src/uu/chcpu/src/chcpu.rs
@@ -1,0 +1,19 @@
+// This file is part of the uutils util-linux package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+use clap::{crate_version, Command};
+use uucore::error::UResult;
+
+#[uucore::main]
+pub fn uumain(_args: impl uucore::Args) -> UResult<()> {
+    println!("chcpu: Hello world");
+    Ok(())
+}
+
+pub fn uu_app() -> Command {
+    Command::new(uucore::util_name())
+        .version(crate_version!())
+        .infer_long_args(true)
+}

--- a/src/uu/chcpu/src/chcpu.rs
+++ b/src/uu/chcpu/src/chcpu.rs
@@ -37,6 +37,21 @@ fn parse_cpu_list(list: &str) -> Vec<usize> {
     out
 }
 
+#[test]
+fn test_parse_cpu_list() {
+    assert_eq!(parse_cpu_list(""), Vec::<usize>::new());
+    assert_eq!(parse_cpu_list("1-3"), Vec::<usize>::from([1, 2, 3]));
+    assert_eq!(parse_cpu_list("1,2,3"), Vec::<usize>::from([1, 2, 3]));
+    assert_eq!(
+        parse_cpu_list("1,3-6,8"),
+        Vec::<usize>::from([1, 3, 4, 5, 6, 8])
+    );
+    assert_eq!(
+        parse_cpu_list("1-2,3-5,7"),
+        Vec::<usize>::from([1, 2, 3, 4, 5, 7])
+    );
+}
+
 #[derive(Debug)]
 struct Cpu(usize);
 

--- a/src/uu/chcpu/src/chcpu.rs
+++ b/src/uu/chcpu/src/chcpu.rs
@@ -45,6 +45,14 @@ impl Cpu {
         PathBuf::from(format!("/sys/devices/system/cpu/cpu{}", self.0))
     }
 
+    fn ensure_exists(&self) -> bool {
+        if !self.get_path().exists() {
+            println!("CPU {} does not exist", self.0);
+            return false;
+        };
+        true
+    }
+
     // CPUs which are not hot-pluggable will not have the `/online` file in their directory
     fn is_hotpluggable(&self) -> bool {
         let path = self.get_path().join("online");
@@ -108,6 +116,10 @@ impl Cpu {
             Err(e) => println!("CPU {} disable failed: {:#}", self.0, e.kind()),
         }
     }
+
+    fn configure(&self) {}
+
+    fn deconfigure(&self) {}
 }
 
 fn get_online_cpus() -> Vec<Cpu> {
@@ -119,7 +131,9 @@ fn enable_cpus(cpu_list: &str) {
     let to_enable = parse_cpu_list(cpu_list).into_iter().map(Cpu);
 
     for cpu in to_enable {
-        cpu.enable();
+        if cpu.ensure_exists() {
+            cpu.enable();
+        };
     }
 }
 
@@ -127,16 +141,28 @@ fn disable_cpus(cpu_list: &str) {
     let to_disable = parse_cpu_list(cpu_list).into_iter().map(Cpu);
 
     for cpu in to_disable {
-        cpu.disable();
+        if cpu.ensure_exists() {
+            cpu.disable();
+        }
     }
 }
 
 fn configure_cpus(cpu_list: &str) {
-    todo!("Configuring CPUs: {}", cpu_list);
+    let to_configure = parse_cpu_list(cpu_list).into_iter().map(Cpu);
+    for cpu in to_configure {
+        if cpu.ensure_exists() {
+            cpu.configure();
+        }
+    }
 }
 
 fn deconfigure_cpus(cpu_list: &str) {
-    todo!("Deconfiguring CPUs: {}", cpu_list);
+    let to_deconfigure = parse_cpu_list(cpu_list).into_iter().map(Cpu);
+    for cpu in to_deconfigure {
+        if cpu.ensure_exists() {
+            cpu.deconfigure();
+        }
+    }
 }
 
 fn set_dispatch_mode(mode: &str) {

--- a/src/uu/chcpu/src/chcpu.rs
+++ b/src/uu/chcpu/src/chcpu.rs
@@ -3,27 +3,144 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
+use std::{
+    fs::{self, File},
+    io::Write,
+    path::PathBuf,
+};
+
 use clap::{crate_version, Arg, ArgAction, ArgGroup, Command};
 use uucore::{error::UResult, format_usage, help_about, help_usage};
 
+// Takes in a human-readable list of CPUs, and returns a list of indices parsed from that list
+// These can come in the form of a plain range like `X-Y`, or a comma-separated ranges and indices ie. `1,3-4,7-8,10`
+// Kernel docs with examples: https://www.kernel.org/doc/html/latest/admin-guide/cputopology.html
+fn parse_cpu_list(list: &str) -> Vec<usize> {
+    let mut out: Vec<usize> = vec![];
+
+    if list.is_empty() {
+        return out;
+    }
+
+    for part in list.trim().split(",") {
+        if part.contains("-") {
+            let bounds: Vec<_> = part.split("-").flat_map(|x| x.parse::<usize>()).collect();
+            assert_eq!(bounds.len(), 2);
+            for idx in bounds[0]..bounds[1] + 1 {
+                out.push(idx)
+            }
+        } else {
+            let idx = part.parse::<usize>().expect("Invalid CPU index value");
+            out.push(idx);
+        }
+    }
+    out
+}
+
+#[derive(Debug)]
+struct Cpu(usize);
+
+impl Cpu {
+    fn get_path(&self) -> PathBuf {
+        PathBuf::from(format!("/sys/devices/system/cpu/cpu{}", self.0))
+    }
+
+    // CPUs which are not hot-pluggable will not have the `/online` file in their directory
+    fn is_hotpluggable(&self) -> bool {
+        let path = self.get_path().join("online");
+        path.exists()
+    }
+
+    fn is_online(&self) -> bool {
+        if let Ok(state) = fs::read_to_string(self.get_path().join("online")) {
+            match state.trim() {
+                "0" => return false,
+                "1" => return true,
+                other => panic!("Unrecognized CPU online state: {}", other),
+            }
+        };
+
+        // Just in case the caller forgot to check `is_hotpluggable` first,
+        // instead of panicing that the file doesn't exist, return true
+        // This is because a non-hotpluggable CPU is assumed to be always online
+        true
+    }
+
+    fn enable(&self) {
+        if !self.is_hotpluggable() {
+            println!("CPU {} is not hot-pluggable", self.0);
+            return;
+        }
+
+        if self.is_online() {
+            println!("CPU {} is already enabled", self.0);
+            return;
+        }
+
+        let result =
+            File::create(self.get_path().join("online")).and_then(|mut f| f.write_all(b"1"));
+        match result {
+            Ok(_) => println!("CPU {} enabled", self.0),
+            Err(e) => println!("CPU {} enable failed: {:#}", self.0, e.kind()),
+        }
+    }
+
+    fn disable(&self) {
+        if !self.is_hotpluggable() {
+            println!("CPU {} is not hot-pluggable", self.0);
+            return;
+        }
+
+        if !self.is_online() {
+            println!("CPU {} is already disabled", self.0);
+            return;
+        }
+
+        if get_online_cpus().len() == 1 {
+            println!("CPU {} disable failed (last enabled CPU)", self.0);
+            return;
+        }
+
+        let result =
+            File::create(self.get_path().join("online")).and_then(|mut f| f.write_all(b"0"));
+        match result {
+            Ok(_) => println!("CPU {} disabled", self.0),
+            Err(e) => println!("CPU {} disable failed: {:#}", self.0, e.kind()),
+        }
+    }
+}
+
+fn get_online_cpus() -> Vec<Cpu> {
+    let cpu_list = fs::read_to_string("/sys/devices/system/cpu/online").unwrap();
+    parse_cpu_list(&cpu_list).iter().map(|n| Cpu(*n)).collect()
+}
+
 fn enable_cpus(cpu_list: &str) {
-    println!("Enabling CPUs: {}", cpu_list)
+    let to_enable = parse_cpu_list(cpu_list).into_iter().map(Cpu);
+
+    for cpu in to_enable {
+        cpu.enable();
+    }
 }
 
 fn disable_cpus(cpu_list: &str) {
-    println!("Disabling CPUs: {}", cpu_list)
+    let to_disable = parse_cpu_list(cpu_list).into_iter().map(Cpu);
+
+    for cpu in to_disable {
+        cpu.disable();
+    }
 }
 
 fn configure_cpus(cpu_list: &str) {
-    println!("Configuring CPUs: {}", cpu_list)
+    todo!("Configuring CPUs: {}", cpu_list);
 }
 
 fn deconfigure_cpus(cpu_list: &str) {
-    println!("Deconfiguring CPUs: {}", cpu_list)
+    todo!("Deconfiguring CPUs: {}", cpu_list);
 }
 
 fn set_dispatch_mode(mode: &str) {
-    println!("Setting dispatch mode to: {}", mode)
+    todo!("Setting dispatch mode to: {}", mode);
 }
 
 #[uucore::main]

--- a/src/uu/chcpu/src/main.rs
+++ b/src/uu/chcpu/src/main.rs
@@ -1,0 +1,1 @@
+uucore::bin!(uu_chcpu);

--- a/tests/by-util/test_chcpu.rs
+++ b/tests/by-util/test_chcpu.rs
@@ -1,0 +1,42 @@
+// This file is part of the uutils util-linux package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+use crate::common::util::TestScenario;
+
+#[test]
+fn test_invalid_arg() {
+    new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
+}
+
+#[test]
+fn test_invalid_cpu_range() {
+    new_ucmd!()
+        .arg("-e")
+        .arg("non-numeric-range")
+        .fails()
+        .code_is(1);
+}
+
+#[test]
+fn test_invalid_cpu_index() {
+    new_ucmd!()
+        .arg("-e")
+        .arg("10000") // Assuming no test environment will ever have 10000 CPUs
+        .fails()
+        .code_is(1)
+        .stderr_contains("CPU 10000 does not exist");
+}
+
+#[test]
+fn test_invalid_dispatch_mode() {
+    new_ucmd!()
+        .arg("-p")
+        .arg("not-horizontal-or-vertical")
+        .fails()
+        .code_is(1)
+        .stderr_contains("Unsupported dispatching mode");
+}
+
+// TODO: Find a way to implement "happy-case" tests that doesn't rely on the host `/sys/` filesystem

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -52,3 +52,7 @@ mod test_dmesg;
 #[cfg(feature = "fsfreeze")]
 #[path = "by-util/test_fsfreeze.rs"]
 mod test_fsfreeze;
+
+#[cfg(feature = "chcpu")]
+#[path = "by-util/test_chcpu.rs"]
+mod test_chcpu;


### PR DESCRIPTION
This PR implements pretty much the entirety of `chcpu`.

Some things still missing:
- Tests: I'm not entirely sure how to properly test something which is so tightly coupled to system internals.
- Exit codes: `chcpu` should return a non-zero exit code in some edge cases. This implementation does check for most such cases, but pretty much always returns a success exit-code. I'm guessing that `uucore::error::UResult` can be used to solve this somehow without having to manually call `std::process::exit()`.