### PR TITLE
Bump `libc` & remove unnecessary `unsafe` blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,9 +382,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.170"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "linux-raw-sys"

--- a/src/uu/blockdev/src/blockdev.rs
+++ b/src/uu/blockdev/src/blockdev.rs
@@ -230,8 +230,8 @@ mod linux {
 
     fn get_partition_offset(device_file: &File) -> UResult<usize> {
         let rdev = device_file.metadata()?.rdev();
-        let major = unsafe { libc::major(rdev) };
-        let minor = unsafe { libc::minor(rdev) };
+        let major = libc::major(rdev);
+        let minor = libc::minor(rdev);
         if Path::new(&format!("/sys/dev/block/{}:{}/partition", major, minor)).exists() {
             let mut start_fd = File::open(format!("/sys/dev/block/{}:{}/start", major, minor))?;
             let mut str = String::new();


### PR DESCRIPTION
This PR bumps `libc` from `0.2.170` to `0.2.171` and removes two `unsafe` blocks in `blockdev` that are no longer necessary.