### PR TITLE
mcookie, lslocks: fix "unused import" warnings in tests

### DIFF
--- a/tests/by-util/test_lslocks.rs
+++ b/tests/by-util/test_lslocks.rs
@@ -3,6 +3,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
+#[cfg(target_os = "linux")]
 use crate::common::util::TestScenario;
 
 #[test]

--- a/tests/by-util/test_mcookie.rs
+++ b/tests/by-util/test_mcookie.rs
@@ -5,7 +5,7 @@
 
 use std::io::Write;
 
-use tempfile::{NamedTempFile, TempDir};
+use tempfile::NamedTempFile;
 
 use crate::common::util::TestScenario;
 


### PR DESCRIPTION
This PR fixes two "unused import" warnings in the tests (see, for example, https://github.com/uutils/util-linux/actions/runs/13988296791/job/39166347016#step:4:275). One warning is solved by removing the import, the other by making the import linux-only.