### PR TITLE
mcookie: add support for human-readable sizes with -m option

### DIFF
--- a/src/uu/mcookie/src/mcookie.rs
+++ b/src/uu/mcookie/src/mcookie.rs
@@ -108,7 +108,7 @@ pub fn uu_app() -> Command {
                 .long("max-size")
                 .value_name("num")
                 .action(ArgAction::Set)
-                .help("limit how much is read from seed files (supports units like KiB, MiB)"),
+                .help("limit how much is read from seed files (supports B suffix or binary units: KiB, MiB, GiB, TiB)"),
         )
         .arg(
             Arg::new(options::VERBOSE)

--- a/src/uu/mcookie/src/mcookie.rs
+++ b/src/uu/mcookie/src/mcookie.rs
@@ -8,7 +8,10 @@ use std::{fs::File, io::Read};
 use clap::{crate_version, Arg, ArgAction, Command};
 use md5::{Digest, Md5};
 use rand::RngCore;
-use uucore::{error::{UResult, USimpleError}, format_usage, help_about, help_usage};
+use uucore::{
+    error::{UResult, USimpleError},
+    format_usage, help_about, help_usage,
+};
 mod size;
 use size::Size;
 

--- a/src/uu/mcookie/src/mcookie.rs
+++ b/src/uu/mcookie/src/mcookie.rs
@@ -8,7 +8,7 @@ use std::{fs::File, io::Read};
 use clap::{crate_version, Arg, ArgAction, Command};
 use md5::{Digest, Md5};
 use rand::RngCore;
-use uucore::{error::UResult, format_usage, help_about, help_usage};
+use uucore::{error::{UResult, USimpleError}, format_usage, help_about, help_usage};
 mod size;
 use size::Size;
 
@@ -37,8 +37,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         match Size::parse(size_str) {
             Ok(size) => Some(size.size_bytes()),
             Err(_) => {
-                eprintln!("Failed to parse max-size value");
-                std::process::exit(1);
+                return Err(USimpleError::new(1, "Failed to parse max-size value"));
             }
         }
     } else {

--- a/src/uu/mcookie/src/size.rs
+++ b/src/uu/mcookie/src/size.rs
@@ -1,3 +1,8 @@
+// This file is part of the uutils util-linux package.
+//
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
 use std::error::Error;
 use std::fmt;
 

--- a/src/uu/mcookie/src/size.rs
+++ b/src/uu/mcookie/src/size.rs
@@ -1,0 +1,49 @@
+use std::num::ParseIntError;
+
+pub struct Size(u64);
+
+impl Size {
+    pub fn parse(s: &str) -> Result<Self, ParseIntError> {
+        let s = s.trim();
+
+        if s.chars().all(char::is_numeric) {
+            return Ok(Self(s.parse::<u64>()?));
+        };
+
+        for (suffix, exponent) in [("K", 1), ("M", 2), ("G", 3), ("T", 4)] {
+            if let Some(nums) = s.strip_suffix(suffix) {
+                let value = nums.trim().parse::<u64>()?;
+                let multiplier = 1024_u64.pow(exponent);
+                return Ok(Self(value * multiplier));
+            }
+        }
+        Ok(Self(s.parse::<u64>()?))
+    }
+
+    pub fn size_bytes(&self) -> u64 {
+        self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_numeric() {
+        assert_eq!(Size::parse("1234").unwrap().size_bytes(), 1234);
+    }
+
+    #[test]
+    fn test_parse_with_suffix() {
+        assert_eq!(Size::parse("1K").unwrap().size_bytes(), 1024);
+        assert_eq!(Size::parse("1M").unwrap().size_bytes(), 1024 * 1024);
+        assert_eq!(Size::parse("1G").unwrap().size_bytes(), 1024 * 1024 * 1024);
+        assert_eq!(Size::parse("1T").unwrap().size_bytes(), 1024 * 1024 * 1024 * 1024);
+    }
+
+    #[test]
+    fn test_invalid_input() {
+        assert!(Size::parse("invalid").is_err());
+    }
+}

--- a/src/uu/mcookie/src/size.rs
+++ b/src/uu/mcookie/src/size.rs
@@ -39,7 +39,10 @@ mod tests {
         assert_eq!(Size::parse("1K").unwrap().size_bytes(), 1024);
         assert_eq!(Size::parse("1M").unwrap().size_bytes(), 1024 * 1024);
         assert_eq!(Size::parse("1G").unwrap().size_bytes(), 1024 * 1024 * 1024);
-        assert_eq!(Size::parse("1T").unwrap().size_bytes(), 1024 * 1024 * 1024 * 1024);
+        assert_eq!(
+            Size::parse("1T").unwrap().size_bytes(),
+            1024 * 1024 * 1024 * 1024
+        );
     }
 
     #[test]

--- a/src/uu/mcookie/src/size.rs
+++ b/src/uu/mcookie/src/size.rs
@@ -20,17 +20,21 @@ impl Size {
 
         // Handle bytes with "B" suffix
         if s.ends_with('B') && !s.ends_with("iB") {
-            let nums = &s[..s.len()-1];
-            return nums.trim().parse::<u64>()
-                .map(Self)
-                .map_err(|_| ParseSizeError(s.to_string()));
+            if let Some(nums) = s.strip_suffix('B') {
+                return nums
+                    .trim()
+                    .parse::<u64>()
+                    .map(Self)
+                    .map_err(|_| ParseSizeError(s.to_string()));
+            }
         }
 
         // Handle binary units (KiB, MiB, GiB, TiB)
         for (suffix, exponent) in [("KiB", 1), ("MiB", 2), ("GiB", 3), ("TiB", 4)] {
-            if s.ends_with(suffix) {
-                let nums = &s[..s.len()-suffix.len()];
-                return nums.trim().parse::<u64>()
+            if let Some(nums) = s.strip_suffix(suffix) {
+                return nums
+                    .trim()
+                    .parse::<u64>()
                     .map(|n| Self(n * 1024_u64.pow(exponent)))
                     .map_err(|_| ParseSizeError(s.to_string()));
             }
@@ -61,7 +65,10 @@ mod tests {
         assert_eq!(Size::parse("1024B").unwrap().size_bytes(), 1024);
         assert_eq!(Size::parse("1KiB").unwrap().size_bytes(), 1024);
         assert_eq!(Size::parse("1MiB").unwrap().size_bytes(), 1024 * 1024);
-        assert_eq!(Size::parse("1GiB").unwrap().size_bytes(), 1024 * 1024 * 1024);
+        assert_eq!(
+            Size::parse("1GiB").unwrap().size_bytes(),
+            1024 * 1024 * 1024
+        );
         assert_eq!(
             Size::parse("1TiB").unwrap().size_bytes(),
             1024 * 1024 * 1024 * 1024

--- a/src/uu/mcookie/src/size.rs
+++ b/src/uu/mcookie/src/size.rs
@@ -1,23 +1,45 @@
-use std::num::ParseIntError;
+use std::error::Error;
+use std::fmt;
+
+#[derive(Debug)]
+pub struct ParseSizeError(String);
+
+impl fmt::Display for ParseSizeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Invalid size format: {}", self.0)
+    }
+}
+
+impl Error for ParseSizeError {}
 
 pub struct Size(u64);
 
 impl Size {
-    pub fn parse(s: &str) -> Result<Self, ParseIntError> {
+    pub fn parse(s: &str) -> Result<Self, ParseSizeError> {
         let s = s.trim();
 
-        if s.chars().all(char::is_numeric) {
-            return Ok(Self(s.parse::<u64>()?));
-        };
+        // Handle bytes with "B" suffix
+        if s.ends_with('B') && !s.ends_with("iB") {
+            let nums = &s[..s.len()-1];
+            return nums.trim().parse::<u64>()
+                .map(Self)
+                .map_err(|_| ParseSizeError(s.to_string()));
+        }
 
-        for (suffix, exponent) in [("K", 1), ("M", 2), ("G", 3), ("T", 4)] {
-            if let Some(nums) = s.strip_suffix(suffix) {
-                let value = nums.trim().parse::<u64>()?;
-                let multiplier = 1024_u64.pow(exponent);
-                return Ok(Self(value * multiplier));
+        // Handle binary units (KiB, MiB, GiB, TiB)
+        for (suffix, exponent) in [("KiB", 1), ("MiB", 2), ("GiB", 3), ("TiB", 4)] {
+            if s.ends_with(suffix) {
+                let nums = &s[..s.len()-suffix.len()];
+                return nums.trim().parse::<u64>()
+                    .map(|n| Self(n * 1024_u64.pow(exponent)))
+                    .map_err(|_| ParseSizeError(s.to_string()));
             }
         }
-        Ok(Self(s.parse::<u64>()?))
+
+        // If no suffix, treat as bytes
+        s.parse::<u64>()
+            .map(Self)
+            .map_err(|_| ParseSizeError(s.to_string()))
     }
 
     pub fn size_bytes(&self) -> u64 {
@@ -36,17 +58,19 @@ mod tests {
 
     #[test]
     fn test_parse_with_suffix() {
-        assert_eq!(Size::parse("1K").unwrap().size_bytes(), 1024);
-        assert_eq!(Size::parse("1M").unwrap().size_bytes(), 1024 * 1024);
-        assert_eq!(Size::parse("1G").unwrap().size_bytes(), 1024 * 1024 * 1024);
+        assert_eq!(Size::parse("1024B").unwrap().size_bytes(), 1024);
+        assert_eq!(Size::parse("1KiB").unwrap().size_bytes(), 1024);
+        assert_eq!(Size::parse("1MiB").unwrap().size_bytes(), 1024 * 1024);
+        assert_eq!(Size::parse("1GiB").unwrap().size_bytes(), 1024 * 1024 * 1024);
         assert_eq!(
-            Size::parse("1T").unwrap().size_bytes(),
+            Size::parse("1TiB").unwrap().size_bytes(),
             1024 * 1024 * 1024 * 1024
         );
     }
 
     #[test]
     fn test_invalid_input() {
+        // Invalid format
         assert!(Size::parse("invalid").is_err());
     }
 }


### PR DESCRIPTION
fixes #257 

took inspiration from CacheSize https://github.com/uutils/util-linux/blob/390d074712bda9815129bc017124a6d7422867db/src/uu/lscpu/src/sysfs.rs#L90C1-L138C1