### PR TITLE
mcookie - fix providing /dev/random or /dev/urandom as file leads to infinite loop

### DIFF
--- a/src/uu/mcookie/src/mcookie.rs
+++ b/src/uu/mcookie/src/mcookie.rs
@@ -20,7 +20,7 @@ mod options {
 const ABOUT: &str = help_about!("mcookie.md");
 const USAGE: &str = help_usage!("mcookie.md");
 
-// Define a default number of bytes to read from character devices if no max-size is given
+// Default number of bytes to read from character devices if no max-size is given
 const DEFAULT_SEED_READ_BYTES: u64 = 1024;
 
 #[uucore::main]
@@ -51,14 +51,11 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
             let mut handle = f.take(*max_bytes);
             handle.read_to_end(&mut buffer)?;
         } else {
-            // Check if the file is a character device (like /dev/random)
             #[cfg(unix)]
             if metadata.file_type().is_char_device() {
-                // Read a limited amount from character devices
                 let mut handle = f.take(DEFAULT_SEED_READ_BYTES);
                 handle.read_to_end(&mut buffer)?;
             } else {
-                // For regular files, read to end
                 f.read_to_end(&mut buffer)?;
             }
         }

--- a/src/uu/mcookie/src/mcookie.rs
+++ b/src/uu/mcookie/src/mcookie.rs
@@ -3,8 +3,9 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
+#[cfg(unix)]
+use std::os::unix::fs::FileTypeExt;
 use std::{fs::File, io::Read};
-#[cfg(unix)] use std::os::unix::fs::FileTypeExt;
 
 use clap::{crate_version, Arg, ArgAction, Command};
 use md5::{Digest, Md5};

--- a/tests/by-util/test_mcookie.rs
+++ b/tests/by-util/test_mcookie.rs
@@ -63,3 +63,34 @@ fn test_seed_files_and_max_size() {
         file2.path().to_str().unwrap()
     ));
 }
+
+#[test]
+#[cfg(unix)] // Character devices like /dev/zero are a Unix concept
+fn test_char_device_input() {
+    let res_no_limit = new_ucmd!().arg("-f").arg("/dev/zero").succeeds();
+
+    let stdout_no_limit = res_no_limit.no_stderr().stdout_str();
+    assert_eq!(stdout_no_limit.trim_end().len(), 32);
+    assert!(stdout_no_limit
+        .trim_end()
+        .chars()
+        .all(|c| c.is_ascii_hexdigit()));
+
+    let res_verbose = new_ucmd!()
+        .arg("--verbose")
+        .arg("-f")
+        .arg("/dev/zero")
+        .succeeds();
+
+    res_verbose.stderr_contains("Got 1024 bytes from /dev/zero");
+    res_verbose.stderr_contains("Got 128 bytes from randomness source"); // Ensure internal randomness is still added
+
+    let stdout_verbose = res_verbose.stdout_str();
+    assert_eq!(stdout_verbose.trim_end().len(), 32);
+    assert!(stdout_verbose
+        .trim_end()
+        .chars()
+        .all(|c| c.is_ascii_hexdigit()));
+
+    assert_ne!(stdout_no_limit, stdout_verbose);
+}

--- a/tests/by-util/test_mcookie.rs
+++ b/tests/by-util/test_mcookie.rs
@@ -71,9 +71,7 @@ fn test_char_device_input() {
 
     let stdout_no_limit = res_no_limit.no_stderr().stdout_str().trim_end();
     assert_eq!(stdout_no_limit.len(), 32);
-    assert!(stdout_no_limit
-        .chars()
-        .all(|c| c.is_ascii_hexdigit()));
+    assert!(stdout_no_limit.chars().all(|c| c.is_ascii_hexdigit()));
 
     let res_verbose = new_ucmd!()
         .arg("--verbose")
@@ -86,9 +84,7 @@ fn test_char_device_input() {
 
     let stdout_verbose = res_verbose.stdout_str().trim_end();
     assert_eq!(stdout_verbose.len(), 32);
-    assert!(stdout_verbose
-        .chars()
-        .all(|c| c.is_ascii_hexdigit()));
+    assert!(stdout_verbose.chars().all(|c| c.is_ascii_hexdigit()));
 
     assert_ne!(stdout_no_limit, stdout_verbose);
 }

--- a/tests/by-util/test_mcookie.rs
+++ b/tests/by-util/test_mcookie.rs
@@ -87,6 +87,7 @@ fn test_char_device_input() {
     assert!(stdout_verbose.chars().all(|c| c.is_ascii_hexdigit()));
 
     assert_ne!(stdout_no_limit, stdout_verbose);
+}
 
 #[test]
 fn test_seed_files_and_max_size_human_readable() {

--- a/tests/by-util/test_mcookie.rs
+++ b/tests/by-util/test_mcookie.rs
@@ -69,10 +69,9 @@ fn test_seed_files_and_max_size() {
 fn test_char_device_input() {
     let res_no_limit = new_ucmd!().arg("-f").arg("/dev/zero").succeeds();
 
-    let stdout_no_limit = res_no_limit.no_stderr().stdout_str();
-    assert_eq!(stdout_no_limit.trim_end().len(), 32);
+    let stdout_no_limit = res_no_limit.no_stderr().stdout_str().trim_end();
+    assert_eq!(stdout_no_limit.len(), 32);
     assert!(stdout_no_limit
-        .trim_end()
         .chars()
         .all(|c| c.is_ascii_hexdigit()));
 
@@ -85,10 +84,9 @@ fn test_char_device_input() {
     res_verbose.stderr_contains("Got 1024 bytes from /dev/zero");
     res_verbose.stderr_contains("Got 128 bytes from randomness source"); // Ensure internal randomness is still added
 
-    let stdout_verbose = res_verbose.stdout_str();
-    assert_eq!(stdout_verbose.trim_end().len(), 32);
+    let stdout_verbose = res_verbose.stdout_str().trim_end();
+    assert_eq!(stdout_verbose.len(), 32);
     assert!(stdout_verbose
-        .trim_end()
         .chars()
         .all(|c| c.is_ascii_hexdigit()));
 


### PR DESCRIPTION
fixes #264 

Fixes an infinite loop when `mcookie` reads from `/dev/random` or `/dev/urandom` without a `--max-size`.

The issue occurred because `read_to_end()` was used on these non-terminating character devices.

This PR checks if the input file is a character device. If so, and no `--max-size` is given, it reads only a limited number of bytes (1024) instead of attempting to read indefinitely. This aligns behavior with the original `mcookie`.

Tested successfully with `/dev/random` and `/dev/urandom`.

