### PR TITLE
Implemented initial version of whereis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1025,6 +1025,7 @@ dependencies = [
  "uu_renice",
  "uu_rev",
  "uu_setsid",
+ "uu_whereis",
  "uucore",
  "xattr",
 ]
@@ -1175,6 +1176,18 @@ version = "0.0.1"
 dependencies = [
  "clap",
  "libc",
+ "uucore",
+]
+
+[[package]]
+name = "uu_whereis"
+version = "0.0.1"
+dependencies = [
+ "clap",
+ "regex",
+ "serde",
+ "serde_json",
+ "sysinfo",
  "uucore",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1184,6 +1184,7 @@ name = "uu_whereis"
 version = "0.0.1"
 dependencies = [
  "clap",
+ "glob",
  "regex",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ feat_common_core = [
   "renice",
   "rev",
   "setsid",
+  "whereis",
 ]
 
 [workspace.dependencies]
@@ -94,6 +95,7 @@ mountpoint = { optional = true, version = "0.0.1", package = "uu_mountpoint", pa
 renice = { optional = true, version = "0.0.1", package = "uu_renice", path = "src/uu/renice" }
 rev = { optional = true, version = "0.0.1", package = "uu_rev", path = "src/uu/rev" }
 setsid = { optional = true, version = "0.0.1", package = "uu_setsid", path ="src/uu/setsid" }
+whereis = { optional = true, version = "0.0.1", package = "uu_whereis", path = "src/uu/whereis" }
 
 [dev-dependencies]
 # dmesg test require fixed-boot-time feature turned on.

--- a/src/uu/whereis/Cargo.toml
+++ b/src/uu/whereis/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "uu_whereis"
+version = "0.0.1"
+edition = "2021"
+
+[lib]
+path = "src/whereis.rs"
+
+[[bin]]
+name = "whereis"
+path = "src/main.rs"
+
+[dependencies]
+regex = { workspace = true }
+uucore = { workspace = true }
+clap = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sysinfo = { workspace = true }

--- a/src/uu/whereis/Cargo.toml
+++ b/src/uu/whereis/Cargo.toml
@@ -17,3 +17,4 @@ clap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sysinfo = { workspace = true }
+glob = "0.3"

--- a/src/uu/whereis/src/constants.rs
+++ b/src/uu/whereis/src/constants.rs
@@ -1,95 +1,83 @@
-
 // List of directories, man, src, and binary
 
-pub const MANDIRS: [&str; 7] = [ 
-	"/usr/man/*",
-	"/usr/share/man/*",
-	"/usr/X386/man/*",
-	"/usr/X11/man/*",
-	"/usr/TeX/man/*",
-	"/usr/interviews/man/mann",
-	"/usr/share/info",
-	// NULL
+pub const MANDIRS: [&str; 7] = [
+    "/usr/man/*",
+    "/usr/share/man/*",
+    "/usr/X386/man/*",
+    "/usr/X11/man/*",
+    "/usr/TeX/man/*",
+    "/usr/interviews/man/mann",
+    "/usr/share/info",
+    // NULL
 ];
 
 pub const SRCDIRS: [&str; 6] = [
-	"/usr/src/*",
-	"/usr/src/lib/libc/*",
-	"/usr/src/lib/libc/net/*",
-	"/usr/src/ucb/pascal",
-	"/usr/src/ucb/pascal/utilities",
-	"/usr/src/undoc",
-	// NULL
+    "/usr/src/*",
+    "/usr/src/lib/libc/*",
+    "/usr/src/lib/libc/net/*",
+    "/usr/src/ucb/pascal",
+    "/usr/src/ucb/pascal/utilities",
+    "/usr/src/undoc",
+    // NULL
 ];
-
 
 pub const BINDIRS: [&str; 46] = [
-	"/usr/bin",
-	"/usr/sbin",
-	"/bin",
-	"/sbin",
+    "/usr/bin",
+    "/usr/sbin",
+    "/bin",
+    "/sbin",
+    // #[cfg(...)]
+    /*
+    #if defined(MULTIARCHTRIPLET)
 
-// #[cfg(...)]
-/* 
-#if defined(MULTIARCHTRIPLET)
+        "/lib/" MULTIARCHTRIPLET,
+        "/usr/lib/" MULTIARCHTRIPLET,
+        "/usr/local/lib/" MULTIARCHTRIPLET,
 
-	"/lib/" MULTIARCHTRIPLET,
-	"/usr/lib/" MULTIARCHTRIPLET,
-	"/usr/local/lib/" MULTIARCHTRIPLET,
-
-#endif
-*/
-
-// #[cfg(not(...))]
-
-	"/usr/lib",
-	"/usr/lib32",
-	"/usr/lib64",
-	"/etc",
-	"/usr/etc",
-	"/lib",
-	"/lib32",
-	"/lib64",
-	"/usr/games",
-	"/usr/games/bin",
-	"/usr/games/lib",
-	"/usr/emacs/etc",
-	"/usr/lib/emacs/*/etc",
-	"/usr/TeX/bin",
-	"/usr/tex/bin",
-	"/usr/interviews/bin/LINUX",
-
-	"/usr/X11R6/bin",
-	"/usr/X386/bin",
-	"/usr/bin/X11",
-	"/usr/X11/bin",
-	"/usr/X11R5/bin",
-
-	"/usr/local/bin",
-	"/usr/local/sbin",
-	"/usr/local/etc",
-	"/usr/local/lib",
-	"/usr/local/games",
-	"/usr/local/games/bin",
-	"/usr/local/emacs/etc",
-	"/usr/local/TeX/bin",
-	"/usr/local/tex/bin",
-	"/usr/local/bin/X11",
-
-	"/usr/contrib",
-	"/usr/hosts",
-	"/usr/include",
-
-	"/usr/g++-include",
-
-	"/usr/ucb",
-	"/usr/old",
-	"/usr/new",
-	"/usr/local",
-	"/usr/libexec",
-	"/usr/share",
-
-	"/opt/*/bin",
-	// NULL
+    #endif
+    */
+    // #[cfg(not(...))]
+    "/usr/lib",
+    "/usr/lib32",
+    "/usr/lib64",
+    "/etc",
+    "/usr/etc",
+    "/lib",
+    "/lib32",
+    "/lib64",
+    "/usr/games",
+    "/usr/games/bin",
+    "/usr/games/lib",
+    "/usr/emacs/etc",
+    "/usr/lib/emacs/*/etc",
+    "/usr/TeX/bin",
+    "/usr/tex/bin",
+    "/usr/interviews/bin/LINUX",
+    "/usr/X11R6/bin",
+    "/usr/X386/bin",
+    "/usr/bin/X11",
+    "/usr/X11/bin",
+    "/usr/X11R5/bin",
+    "/usr/local/bin",
+    "/usr/local/sbin",
+    "/usr/local/etc",
+    "/usr/local/lib",
+    "/usr/local/games",
+    "/usr/local/games/bin",
+    "/usr/local/emacs/etc",
+    "/usr/local/TeX/bin",
+    "/usr/local/tex/bin",
+    "/usr/local/bin/X11",
+    "/usr/contrib",
+    "/usr/hosts",
+    "/usr/include",
+    "/usr/g++-include",
+    "/usr/ucb",
+    "/usr/old",
+    "/usr/new",
+    "/usr/local",
+    "/usr/libexec",
+    "/usr/share",
+    "/opt/*/bin",
+    // NULL
 ];
-

--- a/src/uu/whereis/src/constants.rs
+++ b/src/uu/whereis/src/constants.rs
@@ -1,0 +1,95 @@
+
+// List of directories, man, src, and binary
+
+pub const MANDIRS: [&str; 7] = [ 
+	"/usr/man/*",
+	"/usr/share/man/*",
+	"/usr/X386/man/*",
+	"/usr/X11/man/*",
+	"/usr/TeX/man/*",
+	"/usr/interviews/man/mann",
+	"/usr/share/info",
+	// NULL
+];
+
+pub const SRCDIRS: [&str; 6] = [
+	"/usr/src/*",
+	"/usr/src/lib/libc/*",
+	"/usr/src/lib/libc/net/*",
+	"/usr/src/ucb/pascal",
+	"/usr/src/ucb/pascal/utilities",
+	"/usr/src/undoc",
+	// NULL
+];
+
+
+pub const BINDIRS: [&str; 46] = [
+	"/usr/bin",
+	"/usr/sbin",
+	"/bin",
+	"/sbin",
+
+// #[cfg(...)]
+/* 
+#if defined(MULTIARCHTRIPLET)
+
+	"/lib/" MULTIARCHTRIPLET,
+	"/usr/lib/" MULTIARCHTRIPLET,
+	"/usr/local/lib/" MULTIARCHTRIPLET,
+
+#endif
+*/
+
+// #[cfg(not(...))]
+
+	"/usr/lib",
+	"/usr/lib32",
+	"/usr/lib64",
+	"/etc",
+	"/usr/etc",
+	"/lib",
+	"/lib32",
+	"/lib64",
+	"/usr/games",
+	"/usr/games/bin",
+	"/usr/games/lib",
+	"/usr/emacs/etc",
+	"/usr/lib/emacs/*/etc",
+	"/usr/TeX/bin",
+	"/usr/tex/bin",
+	"/usr/interviews/bin/LINUX",
+
+	"/usr/X11R6/bin",
+	"/usr/X386/bin",
+	"/usr/bin/X11",
+	"/usr/X11/bin",
+	"/usr/X11R5/bin",
+
+	"/usr/local/bin",
+	"/usr/local/sbin",
+	"/usr/local/etc",
+	"/usr/local/lib",
+	"/usr/local/games",
+	"/usr/local/games/bin",
+	"/usr/local/emacs/etc",
+	"/usr/local/TeX/bin",
+	"/usr/local/tex/bin",
+	"/usr/local/bin/X11",
+
+	"/usr/contrib",
+	"/usr/hosts",
+	"/usr/include",
+
+	"/usr/g++-include",
+
+	"/usr/ucb",
+	"/usr/old",
+	"/usr/new",
+	"/usr/local",
+	"/usr/libexec",
+	"/usr/share",
+
+	"/opt/*/bin",
+	// NULL
+];
+

--- a/src/uu/whereis/src/main.rs
+++ b/src/uu/whereis/src/main.rs
@@ -1,0 +1,2 @@
+uucore::bin!(uu_whereis);
+

--- a/src/uu/whereis/src/main.rs
+++ b/src/uu/whereis/src/main.rs
@@ -1,2 +1,1 @@
 uucore::bin!(uu_whereis);
-

--- a/src/uu/whereis/src/whereis.rs
+++ b/src/uu/whereis/src/whereis.rs
@@ -205,6 +205,7 @@ fn find_in(dir: &Path, pathbuf: &PathBuf, results: &mut Vec<String>, dir_type: D
     }
 }
 
+// TODO: Doesn't completely all possible options like specified_bin, etc.
 fn print_output (options: &OutputOptions, pattern: &str, results: Vec<String>) {
 	let mut grouped: HashMap<DirType, Vec<String>> = HashMap::new();
 

--- a/src/uu/whereis/src/whereis.rs
+++ b/src/uu/whereis/src/whereis.rs
@@ -1,29 +1,35 @@
 // This file is a part of the uutils util-linux package.
-
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
 use clap::{crate_version, Arg, ArgAction, Command};
 use serde::Serialize;
-use std::{fs, path::PathBuf};
+use std::{fs, collections::HashSet, collections::HashMap, path::Path, path::PathBuf, os::unix::fs::MetadataExt};
 use uucore::{error::UResult, format_usage, help_about, help_usage};
+use glob::glob;
 
 mod constants;
 use crate::constants::{SRCDIRS, BINDIRS, MANDIRS};
 
 mod options {
-    pub const BYTES: &str = "bytes";
-    pub const HEX: &str = "hex";
-    pub const JSON: &str = "json";
+   	pub const BIN:   &str = "binaries";
+   	pub const MAN:   &str = "manuals";
+    pub const SRC:   &str = "sources";
+    pub const PATH:  &str = "lookups";
+
+    pub const SPECIFIED_BIN: &str = "listed binaries";
+    pub const SPECIFIED_MAN: &str = "listed manuals";
+    pub const SPECIFIED_SRC: &str = "listed sources";
 }
 
 const ABOUT: &str = help_about!("whereis.md");
 const USAGE: &str = help_usage!("whereis.md");
 
-#[derive(Serialize, Clone, Debug)]
+// Directories are usually manual pages dirs, binary dirs or source dirs. Hopefully not unknown.
+#[derive(Serialize, Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub enum DirType {
-	MAN,
 	BIN,
+	MAN,
 	SRC,
 	UNK,
 }
@@ -31,6 +37,7 @@ pub enum DirType {
 // Store the metadata for a file
 #[derive(Serialize, Clone, Debug)]
 pub struct WhDir {
+
 	#[serde(skip_serializing)]
 	#[serde(skip_deserializing)]
 	metadata: Option<fs::Metadata>,	
@@ -50,10 +57,11 @@ impl WhDir {
 
 }
 
-// Use a vector to store the list of directories.
-#[derive(Serialize)]
+// Use a vector to store the list of directories. Additionally keep a HashSet of the inode number and st_dev ID.
+#[derive(Serialize, Debug)]
 pub struct WhDirList {	
-	list: Vec<WhDir>
+	list: Vec<WhDir>,
+	seen_files: HashSet<(u64, u64)>,
 }
 
 impl WhDirList {
@@ -61,11 +69,11 @@ impl WhDirList {
 	fn new () -> Self {
 		Self { 
 			list: Vec::new(), 
+			seen_files: HashSet::new(),
 		}	
 	}
 
 	fn construct_dir_list (&mut self, dir_type: DirType, paths: &[&str]) {
-
 		for path in paths {
 		 	let pathbuf = PathBuf::from(path);
 			if !path.contains('*') {
@@ -77,47 +85,66 @@ impl WhDirList {
 	}
 
 
+	// Use (ino) inode number and (st_dev) ID of device containing the file to keep track of whats unique.
 	fn add_dir (&mut self, dir: WhDir)  {
-
-		// use (ino) inode number and (st_dev) 
 		if self.list.iter().any(|d| d.path == dir.path) {
 			return;
 		}	
 		
-		if let Some(metadata) = &dir.metadata {
-			if metadata.permissions().readonly() {
+		if dir.metadata.is_some() {
+			let dev = dir.metadata.clone().unwrap().dev();
+			let ino = dir.metadata.clone().unwrap().ino();
+
+			if self.seen_files.insert((dev, ino)) {
 				self.list.push(dir);
-			} 
-		}
+			}
+		} 
 	}
-
-	fn add_sub_dirs (&mut self, parent_dir: &PathBuf, dir_type: DirType) {
-
-		if let Ok(entries) = fs::read_dir(parent_dir) {
-			for entry in entries.flatten() {
-				let path = entry.path();
-				if path.is_dir() {
-					self.add_dir(WhDir::new(path, dir_type.clone()));
-				} 
-			} 
-		}
-	}
-
+	
+	#[allow(dead_code)]
 	fn remove_dir (&mut self, dir: &WhDir) {
 		self.list.retain(|d| d.path != dir.path);
 	}
 
+
+	// TODO: We need to do something with the entry if an error occurs. 
+	fn add_sub_dirs (&mut self, parent_dir: &PathBuf, dir_type: DirType) {
+		for entry in glob(&parent_dir.display().to_string()).expect("Failed to read glob pattern") {
+			match entry {
+				Ok(path) if path.is_dir() => {
+					self.add_dir(WhDir::new(path, dir_type.clone()));
+				}
+				Ok(_) => todo!(),
+				Err(_e) => todo!(),
+			}
+		}			
+	}
+
+	// A debug function. 	
+	#[allow(dead_code)]
+	fn list_dirs (&self) {
+		for dir in &self.list {
+			let dir_type = whereis_type_to_name (dir.type_of_dir);
+			println!("{:?} : {:?}", dir_type, dir.path.display());	
+		}	
+	}
+
+
+	fn lookup(&self, pattern: &str, dir_type: DirType) -> Vec<String> {
+		let mut results = Vec::new();
+		let pathbuf_pattern = PathBuf::from(pattern);
+
+		for dir in &self.list {
+			if dir.type_of_dir == dir_type {
+				find_in(&dir.path, &pathbuf_pattern, &mut results, dir.type_of_dir);
+			}
+		}
+
+		results
+	}			
 }
 
-// The output options struct
-struct OutputOptions {
-    bytes: bool,
-    json: bool,
-    _hex: bool,
-}
-
-pub fn whereis_type_to_name (dir_type: &DirType) -> &'static str {
-
+pub fn whereis_type_to_name (dir_type: DirType) -> &'static str {
 	match dir_type {
 		DirType::MAN => "man",
 		DirType::BIN => "bin",
@@ -126,8 +153,108 @@ pub fn whereis_type_to_name (dir_type: &DirType) -> &'static str {
 	}
 }
 
+// Almost an exact ripoff from the C source. 
+fn filename_equal(cp: &PathBuf, dp: &str, dir_type: DirType) -> bool {
+    let cp_str = match cp.file_name().and_then(|s| s.to_str()) {
+        Some(s) => s,
+        None => return false,
+    };
 
-// pub fn build_dir_list (dir_list: &WhDirList)  -> None { }
+    let mut dp_trimmed = dp;
+
+    if dir_type == DirType::SRC && dp_trimmed.starts_with("s.") {
+        return filename_equal(cp, &dp_trimmed[2..], dir_type);
+    }
+
+    if dir_type == DirType::MAN {
+        for ext in [".Z", ".gz", ".xz", ".bz2", ".zst"] {
+            if let Some(stripped) = dp_trimmed.strip_suffix(ext) {
+                dp_trimmed = stripped;
+                break;
+            }
+        }
+    }
+
+    let mut cp_chars = cp_str.chars();
+    let mut dp_chars = dp_trimmed.chars();
+
+    loop {
+        match (cp_chars.next(), dp_chars.next()) {
+            (Some(c1), Some(c2)) if c1 == c2 => continue,
+            (None, None) => return true, // both ended
+            (None, Some('.')) if dir_type != DirType::BIN => {
+                // cp ended, dp has .section
+                return true;
+            }
+            _ => return false,
+        }
+    }
+}
+
+
+fn find_in(dir: &Path, pathbuf: &PathBuf, results: &mut Vec<String>, dir_type: DirType) {
+    if let Ok(entries) = fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if let Some(filename) = path.file_name().and_then(|f| f.to_str()) {
+                if filename_equal(pathbuf, filename, dir_type) {
+                    results.push(path.display().to_string());
+                }
+            }
+        }
+    }
+}
+
+fn print_output (options: &OutputOptions, pattern: &str, results: Vec<String>) {
+	let mut grouped: HashMap<DirType, Vec<String>> = HashMap::new();
+
+    // Split results by type, grouping MAN, BIN and SRC.
+    for path in results {
+        if path.contains("/bin/") {
+            grouped.entry(DirType::BIN).or_default().push(path);
+        } else if path.contains("/man") || path.contains("/share/man") {
+            grouped.entry(DirType::MAN).or_default().push(path);
+        } else {
+            grouped.entry(DirType::SRC).or_default().push(path);
+        }
+    }
+
+    print!("{}:", pattern);
+
+    // If *any* of the search flags are set, print according to them
+    if options.search_bin || options.search_man || options.search_src {
+        if options.search_bin {
+            if let Some(paths) = grouped.get(&DirType::BIN) {
+                for path in paths {
+                    print!(" {}", path);
+                }
+            }
+        }
+        if options.search_man {
+            if let Some(paths) = grouped.get(&DirType::MAN) {
+                for path in paths {
+                    print!(" {}", path);
+                }
+            }
+        }
+        if options.search_src {
+            if let Some(paths) = grouped.get(&DirType::SRC) {
+                for path in paths {
+                    print!(" {}", path);
+                }
+            }
+        }
+    } else {
+        // No -b/-m/-s flag given? Print everything
+        for paths in grouped.values() {
+            for path in paths {
+                print!(" {}", path);
+            }
+        }
+    }
+
+    println!();
+}
 
 
 #[uucore::main]
@@ -135,57 +262,150 @@ pub fn uumain(args: impl uucore::Args) -> UResult <()> {
 
 	let matches: clap::ArgMatches = uu_app().try_get_matches_from(args)?;
 
-    let _output_opts = OutputOptions {
-        bytes: matches.get_flag(options::BYTES),
-        _hex: matches.get_flag(options::HEX),
-        json: matches.get_flag(options::JSON),
-    };
+    let output_options = OutputOptions {
+     	search_bin: matches.get_flag(options::BIN),
+      	search_man: matches.get_flag(options::MAN),
+       	search_src: matches.get_flag(options::SRC),
+       	path_given: matches.get_flag(options::PATH),
 
-	
+       	search_specific_bin: matches.get_flag(options::SPECIFIED_BIN),
+       	search_specific_man: matches.get_flag(options::SPECIFIED_MAN),
+       	search_specific_src: matches.get_flag(options::SPECIFIED_SRC),
+    };   	
+
+	let mut dir_list = WhDirList::new();
+
+	dir_list.construct_dir_list(DirType::BIN, &BINDIRS);
+	dir_list.construct_dir_list(DirType::MAN, &MANDIRS);
+	dir_list.construct_dir_list(DirType::SRC, &SRCDIRS);
+
+	let names: Vec<_> = matches.get_many::<String>("names")
+		.unwrap()
+		.map(|s| s.as_str())
+		.collect();
+
+	// Search for the names that were passed into the program.
+	for pattern in names {
+		let mut results = dir_list.lookup(pattern, DirType::BIN);
+		results.append(&mut dir_list.lookup(pattern, DirType::MAN));
+		results.append(&mut dir_list.lookup(pattern, DirType::SRC));
+
+		print_output(&output_options, pattern, results);	
+	}
+
 	Ok(())
 }
+	
+// TODO: Implement the necessary behavior for path_given and other fields with the dead_code macro.	
+struct OutputOptions {
+    search_bin: bool,
+    search_man: bool,
+    search_src: bool,
 
+	#[allow(dead_code)]
+    path_given: bool,
 
-// Fix this, there is -b -B <dirs> -m -M <dirs> -s -S <dirs> -f -u -g and -i
+	#[allow(dead_code)]
+    search_specific_bin: bool,
+
+	#[allow(dead_code)]
+    search_specific_man: bool,
+
+	#[allow(dead_code)]
+    search_specific_src: bool,
+}
+
 pub fn uu_app() -> Command {
     Command::new(uucore::util_name())
         .version(crate_version!())
         .about(ABOUT)
         .override_usage(format_usage(USAGE))
         .infer_long_args(true)
+
+		.arg(
+			Arg::new("names")
+				.help("The name of the program [s] to search for.")
+				.num_args(1..)
+				.required(true)
+		)
         .arg(
-            Arg::new(options::HEX)
-                .short('x')
-                .long("hex")
+            Arg::new(options::BIN)
+                .short('b')
+                .long("binaries")
                 .action(ArgAction::SetTrue)
-                .help(
-                    "Use hexadecimal masks for CPU sets (for example 'ff'). \
-                    The default is to print the sets in list format (for example 0,1).",
-                )
+                .help("Search for binaries.")
                 .required(false),
         )
         .arg(
-            Arg::new(options::JSON)
-                .short('J')
-                .long("json")
-                .help(
-                    "Use JSON output format for the default summary or extended output \
-                    (see --extended). For backward compatibility, JSON output follows the \
-                    default summary behavior for non-terminals (e.g., pipes) where \
-                    subsections are missing. See also --hierarchic.",
-                )
-                .action(ArgAction::SetTrue),
+            Arg::new(options::MAN)
+                .short('m')
+                .long("manual")
+                .help("Search for manuals.")
+                .action(ArgAction::SetTrue)
+				.required(false),
         )
         .arg(
-            Arg::new(options::BYTES)
+            Arg::new(options::SRC)
+                .short('s')
+                .long("source")
+                .action(ArgAction::SetTrue)
+                .help("Search for sources.")
+				.action(ArgAction::SetTrue)
+				.required(false),
+        )
+		.arg(
+            Arg::new(options::SPECIFIED_BIN)
                 .short('B')
-                .long("bytes")
+                .long("bins")
                 .action(ArgAction::SetTrue)
                 .help(
-                    "Print the sizes in bytes rather than in a human-readable format. \
-                    The default is to print sizes in human-readable format (for example '512 KiB'). \
-                    Setting this flag instead prints the decimal amount of bytes with no suffix.",
-                ),
+					"Limit the places where whereis searches for binaries, \
+				    by a whitespace-separated list of directories."	
+                )
+				.action(ArgAction::SetTrue)
+				.required(false),
         )
+		.arg(
+            Arg::new(options::SPECIFIED_MAN)
+                .short('M')
+                .long("mans")
+                .action(ArgAction::SetTrue)
+                .help(
+					 "Limit the places where whereis searches for manuals and documentation in Info \
+           			 format, by a whitespace-separated list of directories."
+                )
+				.action(ArgAction::SetTrue)
+				.required(false),
+        )
+		.arg(
+            Arg::new(options::SPECIFIED_SRC)
+                .short('S')
+                .long("sources")
+                .action(ArgAction::SetTrue)
+                .help(
+					"Limit the places where whereis searches for sources, by a whitespace-separated \
+		            list of directories."
+                )
+				.action(ArgAction::SetTrue)
+				.required(false),
+        )
+
+		// Want to rename this in the future. 
+		.arg(
+            Arg::new(options::PATH)
+                .short('u')
+                .long("source path")
+                .action(ArgAction::SetTrue)
+                .help(
+					"Only show the command names that have unusual entries. A command is said to be \
+				    unusual if it does not have just one entry of each explicitly requested type. \
+                    Thus 'whereis -m -u *' asks for those files in the current directory which \
+				    have no documentation file, or more than one."
+                )
+				.action(ArgAction::SetTrue)
+				.required(false),
+        )
+
+
 }
 

--- a/src/uu/whereis/src/whereis.rs
+++ b/src/uu/whereis/src/whereis.rs
@@ -1,0 +1,191 @@
+// This file is a part of the uutils util-linux package.
+
+// For the full copyright and license information, please view the LICENSE
+// file that was distributed with this source code.
+
+use clap::{crate_version, Arg, ArgAction, Command};
+use serde::Serialize;
+use std::{fs, path::PathBuf};
+use uucore::{error::UResult, format_usage, help_about, help_usage};
+
+mod constants;
+use crate::constants::{SRCDIRS, BINDIRS, MANDIRS};
+
+mod options {
+    pub const BYTES: &str = "bytes";
+    pub const HEX: &str = "hex";
+    pub const JSON: &str = "json";
+}
+
+const ABOUT: &str = help_about!("whereis.md");
+const USAGE: &str = help_usage!("whereis.md");
+
+#[derive(Serialize, Clone, Debug)]
+pub enum DirType {
+	MAN,
+	BIN,
+	SRC,
+	UNK,
+}
+
+// Store the metadata for a file
+#[derive(Serialize, Clone, Debug)]
+pub struct WhDir {
+	#[serde(skip_serializing)]
+	#[serde(skip_deserializing)]
+	metadata: Option<fs::Metadata>,	
+	path: PathBuf, 	
+	type_of_dir: DirType
+} 
+
+impl WhDir {
+
+	fn new (path: PathBuf, type_of_dir: DirType) -> Self {
+		Self {
+			metadata: fs::metadata(&path).ok(),
+			path,
+			type_of_dir,
+		}
+	}
+
+}
+
+// Use a vector to store the list of directories.
+#[derive(Serialize)]
+pub struct WhDirList {	
+	list: Vec<WhDir>
+}
+
+impl WhDirList {
+
+	fn new () -> Self {
+		Self { 
+			list: Vec::new(), 
+		}	
+	}
+
+	fn construct_dir_list (&mut self, dir_type: DirType, paths: &[&str]) {
+
+		for path in paths {
+		 	let pathbuf = PathBuf::from(path);
+			if !path.contains('*') {
+				self.add_dir (WhDir::new(pathbuf, dir_type.clone()));
+			} else {
+				self.add_sub_dirs(&pathbuf, dir_type.clone());
+			} 
+		}
+	}
+
+
+	fn add_dir (&mut self, dir: WhDir)  {
+
+		// use (ino) inode number and (st_dev) 
+		if self.list.iter().any(|d| d.path == dir.path) {
+			return;
+		}	
+		
+		if let Some(metadata) = &dir.metadata {
+			if metadata.permissions().readonly() {
+				self.list.push(dir);
+			} 
+		}
+	}
+
+	fn add_sub_dirs (&mut self, parent_dir: &PathBuf, dir_type: DirType) {
+
+		if let Ok(entries) = fs::read_dir(parent_dir) {
+			for entry in entries.flatten() {
+				let path = entry.path();
+				if path.is_dir() {
+					self.add_dir(WhDir::new(path, dir_type.clone()));
+				} 
+			} 
+		}
+	}
+
+	fn remove_dir (&mut self, dir: &WhDir) {
+		self.list.retain(|d| d.path != dir.path);
+	}
+
+}
+
+// The output options struct
+struct OutputOptions {
+    bytes: bool,
+    json: bool,
+    _hex: bool,
+}
+
+pub fn whereis_type_to_name (dir_type: &DirType) -> &'static str {
+
+	match dir_type {
+		DirType::MAN => "man",
+		DirType::BIN => "bin",
+		DirType::SRC => "src",
+		DirType::UNK => "???",
+	}
+}
+
+
+// pub fn build_dir_list (dir_list: &WhDirList)  -> None { }
+
+
+#[uucore::main]
+pub fn uumain(args: impl uucore::Args) -> UResult <()> {
+
+	let matches: clap::ArgMatches = uu_app().try_get_matches_from(args)?;
+
+    let _output_opts = OutputOptions {
+        bytes: matches.get_flag(options::BYTES),
+        _hex: matches.get_flag(options::HEX),
+        json: matches.get_flag(options::JSON),
+    };
+
+	
+	Ok(())
+}
+
+
+// Fix this, there is -b -B <dirs> -m -M <dirs> -s -S <dirs> -f -u -g and -i
+pub fn uu_app() -> Command {
+    Command::new(uucore::util_name())
+        .version(crate_version!())
+        .about(ABOUT)
+        .override_usage(format_usage(USAGE))
+        .infer_long_args(true)
+        .arg(
+            Arg::new(options::HEX)
+                .short('x')
+                .long("hex")
+                .action(ArgAction::SetTrue)
+                .help(
+                    "Use hexadecimal masks for CPU sets (for example 'ff'). \
+                    The default is to print the sets in list format (for example 0,1).",
+                )
+                .required(false),
+        )
+        .arg(
+            Arg::new(options::JSON)
+                .short('J')
+                .long("json")
+                .help(
+                    "Use JSON output format for the default summary or extended output \
+                    (see --extended). For backward compatibility, JSON output follows the \
+                    default summary behavior for non-terminals (e.g., pipes) where \
+                    subsections are missing. See also --hierarchic.",
+                )
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new(options::BYTES)
+                .short('B')
+                .long("bytes")
+                .action(ArgAction::SetTrue)
+                .help(
+                    "Print the sizes in bytes rather than in a human-readable format. \
+                    The default is to print sizes in human-readable format (for example '512 KiB'). \
+                    Setting this flag instead prints the decimal amount of bytes with no suffix.",
+                ),
+        )
+}
+

--- a/src/uu/whereis/whereis.md
+++ b/src/uu/whereis/whereis.md
@@ -1,7 +1,7 @@
 # whereis
 
 ```
-whereis [OPTION] ...
+whereis [options] [-BMS directory... -f] name...
 ```
 Locates the binary, source and manual pages for a command.
 

--- a/src/uu/whereis/whereis.md
+++ b/src/uu/whereis/whereis.md
@@ -1,0 +1,7 @@
+# whereis
+
+```
+whereis [OPTION] ...
+```
+Locates the binary, source and manual pages for a command.
+

--- a/tests/by-util/test_whereis.rs
+++ b/tests/by-util/test_whereis.rs
@@ -3,32 +3,46 @@ use crate::common::util::TestScenario;
 #[test]
 #[cfg(target_os = "linux")]
 fn test_basic_lookup() {
-    new_ucmd!().arg("gcc").succeeds().stdout_contains("/usr/bin/gcc");
+    new_ucmd!()
+        .arg("gcc")
+        .succeeds()
+        .stdout_contains("/usr/bin/gcc");
 }
 
 #[test]
 #[cfg(target_os = "linux")]
 fn test_bin_only() {
-    new_ucmd!().arg("-b").arg("ping").succeeds().stdout_contains("/usr/bin/ping");
+    new_ucmd!()
+        .arg("-b")
+        .arg("ping")
+        .succeeds()
+        .stdout_contains("/usr/bin/ping");
 }
 
 #[test]
 #[cfg(target_os = "linux")]
 fn test_man_only() {
-    new_ucmd!().arg("-m").arg("nmap").succeeds().stdout_contains("/usr/share/man/man1/nmap.1.gz");
+    new_ucmd!()
+        .arg("-m")
+        .arg("nmap")
+        .succeeds()
+        .stdout_contains("/usr/share/man/man1/nmap.1.gz");
 }
 
 #[test]
 #[cfg(target_os = "linux")]
 // dig doesn't seem to have any output when passing in the -s flag.
 fn test_src_only() {
-    new_ucmd!().arg("-s").arg("dig").succeeds().stdout_contains("");
+    new_ucmd!()
+        .arg("-s")
+        .arg("dig")
+        .succeeds()
+        .stdout_contains("");
 }
 
 #[test]
 #[cfg(target_os = "linux")]
 fn test_output() {
-
     let res = new_ucmd!().arg("ping").arg("gcc").succeeds();
     let stdout = res.no_stderr().stdout_str();
 
@@ -40,8 +54,7 @@ fn test_output() {
     // Check that paths are printed next to the command name, as expected
     assert!(stdout.contains("/usr/bin/ping"));
     assert!(stdout.contains("/usr/bin/gcc"));
-    
+
     assert!(stdout.contains("/usr/lib/gcc"));
     assert!(stdout.contains("/usr/share/gcc"));
 }
-

--- a/tests/by-util/test_whereis.rs
+++ b/tests/by-util/test_whereis.rs
@@ -1,0 +1,47 @@
+use crate::common::util::TestScenario;
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_basic_lookup() {
+    new_ucmd!().arg("gcc").succeeds().stdout_contains("/usr/bin/gcc");
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_bin_only() {
+    new_ucmd!().arg("-b").arg("ping").succeeds().stdout_contains("/usr/bin/ping");
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_man_only() {
+    new_ucmd!().arg("-m").arg("nmap").succeeds().stdout_contains("/usr/share/man/man1/nmap.1.gz");
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+// dig doesn't seem to have any output when passing in the -s flag.
+fn test_src_only() {
+    new_ucmd!().arg("-s").arg("dig").succeeds().stdout_contains("");
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_output() {
+
+    let res = new_ucmd!().arg("ping").arg("gcc").succeeds();
+    let stdout = res.no_stderr().stdout_str();
+
+    // Non-exhaustive list of fields we expect
+    // Check that 'ping' and 'gcc' have their paths listed
+    assert!(stdout.contains("ping:"));
+    assert!(stdout.contains("gcc:"));
+
+    // Check that paths are printed next to the command name, as expected
+    assert!(stdout.contains("/usr/bin/ping"));
+    assert!(stdout.contains("/usr/bin/gcc"));
+    
+    assert!(stdout.contains("/usr/lib/gcc"));
+    assert!(stdout.contains("/usr/share/gcc"));
+}
+

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -60,3 +60,7 @@ mod test_fsfreeze;
 #[cfg(feature = "mcookie")]
 #[path = "by-util/test_mcookie.rs"]
 mod test_mcookie;
+
+#[cfg(feature = "whereis")]
+#[path = "by-util/test_whereis.rs"]
+mod test_whereis;


### PR DESCRIPTION
This PR focuses on basic functionality of the whereis utility. 

Current Issues with the current implementation:
- The order of the output doesn't exactly match the original whereis C utility. 
- I am not sure how to handle errors in ```WhDirList::add_sub_dirs```
- How would I make the tests cover more cases? 
- Could there be some use of a shell script to compare the output of the original commands with the re-implemented commands to check for correctness? 

Future work could include:
- Improving matching for partial results, and clearing up some issues in the ``` uu_app ``` function where naming is concerned. 

I am happy to iterate further based on feedback!