### PR TITLE
mesg: move `uu_app()` to bottom of file

### DIFF
--- a/src/uu/mesg/src/mesg.rs
+++ b/src/uu/mesg/src/mesg.rs
@@ -68,6 +68,17 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     Ok(())
 }
 
+#[cfg(not(target_family = "unix"))]
+#[uucore::main]
+pub fn uumain(args: impl uucore::Args) -> UResult<()> {
+    let _matches: ArgMatches = uu_app().try_get_matches_from(args)?;
+
+    Err(uucore::error::USimpleError::new(
+        1,
+        "`mesg` is available only on Unix platforms.",
+    ))
+}
+
 pub fn uu_app() -> Command {
     Command::new(uucore::util_name())
         .version(crate_version!())
@@ -87,15 +98,4 @@ pub fn uu_app() -> Command {
                 .value_parser(PossibleValuesParser::new(["y", "n"]))
                 .action(ArgAction::Set),
         )
-}
-
-#[cfg(not(target_family = "unix"))]
-#[uucore::main]
-pub fn uumain(args: impl uucore::Args) -> UResult<()> {
-    let _matches: ArgMatches = uu_app().try_get_matches_from(args)?;
-
-    Err(uucore::error::USimpleError::new(
-        1,
-        "`mesg` is available only on Unix platforms.",
-    ))
 }


### PR DESCRIPTION
Currently, `uu_app()` is sandwiched between two `uumain()` function. To "un-sandwich" it, this PR moves `uu_app()` to the bottom of the file.