### PR TITLE
Bump nix & adapt to its API changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,7 +345,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -472,7 +472,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -540,6 +540,18 @@ name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -889,7 +901,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -902,7 +914,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1052,7 +1064,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix 1.0.5",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1169,7 +1181,7 @@ dependencies = [
  "clap_mangen",
  "dns-lookup",
  "libc",
- "nix",
+ "nix 0.30.1",
  "phf",
  "phf_codegen",
  "pretty_assertions",
@@ -1326,7 +1338,7 @@ name = "uu_mesg"
 version = "0.0.1"
 dependencies = [
  "clap",
- "nix",
+ "nix 0.30.1",
  "uucore",
 ]
 
@@ -1369,7 +1381,7 @@ name = "uu_uuidgen"
 version = "0.0.1"
 dependencies = [
  "clap",
- "nix",
+ "nix 0.30.1",
  "rand 0.9.1",
  "thiserror",
  "uucore",
@@ -1390,7 +1402,7 @@ dependencies = [
  "glob",
  "iana-time-zone",
  "libc",
- "nix",
+ "nix 0.29.0",
  "number_prefix",
  "os_display",
  "time",
@@ -1552,7 +1564,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ libc = "0.2.171"
 libmount-sys = "0.1.1"
 linux-raw-sys = { version = "0.9.0", features = ["ioctl"] }
 md-5 = "0.10.6"
-nix = { version = "0.29", default-features = false }
+nix = { version = "0.30", default-features = false }
 phf = "0.11.2"
 phf_codegen = "0.11.2"
 rand = { version = "0.9.0", features = ["small_rng"] }

--- a/src/uu/mesg/Cargo.toml
+++ b/src/uu/mesg/Cargo.toml
@@ -12,5 +12,5 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { workspace = true }
-nix = { workspace = true }
+nix = { workspace = true, features = ["fs"] }
 uucore = { workspace = true }


### PR DESCRIPTION
This PR bumps `nix` from `0.29.0` to `0.30.1` and adapts `mesg` to the API changes in `nix`.