### PR TITLE
Bump `phf_codegen` & fix compilation error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,37 +691,28 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
 dependencies = [
- "phf_shared 0.12.1",
+ "phf_shared",
  "serde",
 ]
 
 [[package]]
 name = "phf_codegen"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+checksum = "efbdcb6f01d193b17f0b9c3360fa7e0e620991b193ff08702f78b3ce365d7e61"
 dependencies = [
  "phf_generator",
- "phf_shared 0.11.3",
+ "phf_shared",
 ]
 
 [[package]]
 name = "phf_generator"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+checksum = "2cbb1126afed61dd6368748dae63b1ee7dc480191c6262a3b4ff1e29d86a6c5b"
 dependencies = [
- "phf_shared 0.11.3",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
+ "fastrand",
+ "phf_shared",
 ]
 
 [[package]]
@@ -794,21 +785,12 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
- "rand_core 0.9.3",
+ "rand_core",
 ]
 
 [[package]]
@@ -818,14 +800,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rand_core"
@@ -1222,7 +1198,7 @@ dependencies = [
  "phf",
  "phf_codegen",
  "pretty_assertions",
- "rand 0.9.2",
+ "rand",
  "regex",
  "rlimit",
  "serde",
@@ -1365,7 +1341,7 @@ version = "0.0.1"
 dependencies = [
  "clap",
  "md-5",
- "rand 0.9.2",
+ "rand",
  "uucore",
 ]
 
@@ -1418,7 +1394,7 @@ version = "0.0.1"
 dependencies = [
  "clap",
  "nix",
- "rand 0.9.2",
+ "rand",
  "thiserror",
  "uucore",
  "uuid",
@@ -1473,7 +1449,7 @@ dependencies = [
  "getrandom",
  "js-sys",
  "md-5",
- "rand 0.9.2",
+ "rand",
  "sha1_smol",
  "uuid-rng-internal",
  "wasm-bindgen",
@@ -1485,7 +1461,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11c277e43528edc5dd4660d28b2e61d70dff7f4f91502fe6a9a917eb61e427e9"
 dependencies = [
- "rand 0.9.2",
+ "rand",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ linux-raw-sys = { version = "0.9.0", features = ["ioctl"] }
 md-5 = "0.10.6"
 nix = { version = "0.30", default-features = false }
 phf = "0.12.0"
-phf_codegen = "0.11.2"
+phf_codegen = "0.12.1"
 rand = { version = "0.9.0", features = ["small_rng"] }
 rangemap = "1.5.1"
 regex = "1.10.2"

--- a/build.rs
+++ b/build.rs
@@ -53,7 +53,7 @@ pub fn main() {
     let mut phf_map = phf_codegen::OrderedMap::<&str>::new();
     for krate in &crates {
         let map_value = format!("({krate}::uumain, {krate}::uu_app)");
-        phf_map.entry(krate, &map_value);
+        phf_map.entry(krate, map_value);
     }
     write!(mf, "{}", phf_map.build()).unwrap();
     mf.write_all(b"\n}\n").unwrap();


### PR DESCRIPTION
This PR bumps `phf_codegen` from `0.11.2` to `0.12.1` and fixes a "does not live long enough" error in `build.rs`.