### PR TITLE
clippy: fix warnings from `uninlined_format_args`

### DIFF
--- a/src/uu/blockdev/src/blockdev.rs
+++ b/src/uu/blockdev/src/blockdev.rs
@@ -232,8 +232,8 @@ mod linux {
         let rdev = device_file.metadata()?.rdev();
         let major = libc::major(rdev);
         let minor = libc::minor(rdev);
-        if Path::new(&format!("/sys/dev/block/{}:{}/partition", major, minor)).exists() {
-            let mut start_fd = File::open(format!("/sys/dev/block/{}:{}/start", major, minor))?;
+        if Path::new(&format!("/sys/dev/block/{major}:{minor}/partition")).exists() {
+            let mut start_fd = File::open(format!("/sys/dev/block/{major}:{minor}/start"))?;
             let mut str = String::new();
             start_fd.read_to_string(&mut str)?;
             return str
@@ -286,21 +286,21 @@ mod linux {
             IoctlCommand::GetAttribute(ioctl_type) => {
                 let ret = unsafe { get_ioctl_attribute(device, ioctl_code, *ioctl_type)? };
                 if verbose {
-                    println!("{}: {}", name, ret);
+                    println!("{name}: {ret}");
                 } else {
-                    println!("{}", ret);
+                    println!("{ret}");
                 }
             }
             IoctlCommand::SetAttribute => {
                 unsafe { uu_ioctl(device, ioctl_code, arg)? };
                 if verbose {
-                    println!("{} succeeded.", name);
+                    println!("{name} succeeded.");
                 }
             }
             IoctlCommand::Operation(param) => {
                 unsafe { uu_ioctl(device, ioctl_code, param)? };
                 if verbose {
-                    println!("{} succeeded.", name);
+                    println!("{name} succeeded.");
                 }
             }
         };
@@ -359,7 +359,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
                             *value,
                         ) {
                             if verbose {
-                                println!("{} failed.", description);
+                                println!("{description} failed.");
                             }
                             return Err(e);
                         }

--- a/src/uu/dmesg/src/dmesg.rs
+++ b/src/uu/dmesg/src/dmesg.rs
@@ -443,8 +443,7 @@ fn record_regex() -> &'static Regex {
         let valid_number_pattern = "0|[1-9][0-9]*";
         let additional_fields_pattern = ",^[,;]*";
         let record_pattern = format!(
-            "(?m)^({0}),({0}),({0}),.(?:{1})*;(.*)$",
-            valid_number_pattern, additional_fields_pattern
+            "(?m)^({valid_number_pattern}),({valid_number_pattern}),({valid_number_pattern}),.(?:{additional_fields_pattern})*;(.*)$"
         );
         Regex::new(&record_pattern).expect("invalid regex.")
     })

--- a/src/uu/dmesg/src/json.rs
+++ b/src/uu/dmesg/src/json.rs
@@ -136,7 +136,7 @@ impl serde_json::ser::Formatter for DmesgFormatter {
         // The only i64 field in Dmesg is time, which requires a specific format
         let seconds = value / 1000000;
         let sub_seconds = value % 1000000;
-        let repr = format!("{:>5}.{:0>6}", seconds, sub_seconds);
+        let repr = format!("{seconds:>5}.{sub_seconds:0>6}");
         writer.write_all(repr.as_bytes())
     }
 }

--- a/src/uu/dmesg/src/time_formatter.rs
+++ b/src/uu/dmesg/src/time_formatter.rs
@@ -12,7 +12,7 @@ use uucore::error::{UResult, USimpleError};
 pub fn raw(timestamp_us: i64) -> String {
     let seconds = timestamp_us / 1000000;
     let sub_seconds = timestamp_us % 1000000;
-    format!("{:>5}.{:0>6}", seconds, sub_seconds)
+    format!("{seconds:>5}.{sub_seconds:0>6}")
 }
 
 pub fn ctime(timestamp_us: i64) -> String {
@@ -80,8 +80,8 @@ impl ReltimeFormatter {
         let seconds = i64::abs(delta_us / 1000000);
         let sub_seconds = i64::abs(delta_us % 1000000);
         let sign = if delta_us >= 0 { '+' } else { '-' };
-        let res = format!("{}{}.{:0>6}", sign, seconds, sub_seconds);
-        format!("{:>11}", res)
+        let res = format!("{sign}{seconds}.{sub_seconds:0>6}");
+        format!("{res:>11}")
     }
 }
 
@@ -109,11 +109,11 @@ impl DeltaFormatter {
     fn delta(delta_us: i64) -> String {
         let seconds = i64::abs(delta_us / 1000000);
         let sub_seconds = i64::abs(delta_us % 1000000);
-        let mut res = format!("{}.{:0>6}", seconds, sub_seconds);
+        let mut res = format!("{seconds}.{sub_seconds:0>6}");
         if delta_us < 0 {
             res.insert(0, '-');
         }
-        format!("<{:>12}>", res)
+        format!("<{res:>12}>")
     }
 }
 

--- a/src/uu/last/src/platform/unix.rs
+++ b/src/uu/last/src/platform/unix.rs
@@ -24,10 +24,7 @@ use std::str::FromStr;
 use std::time::Duration;
 
 fn get_long_usage() -> String {
-    format!(
-        "If FILE is not specified, use {}.  /var/log/wtmp as FILE is common.",
-        WTMP_PATH,
-    )
+    format!("If FILE is not specified, use {WTMP_PATH}.  /var/log/wtmp as FILE is common.")
 }
 
 const WTMP_PATH: &str = "/var/log/wtmp";
@@ -151,9 +148,9 @@ fn duration_string(duration: time::Duration) -> String {
     let minutes = seconds / 60;
 
     if days > 0 {
-        format!("({}+{:0>2}:{:0>2})", days, hours, minutes)
+        format!("({days}+{hours:0>2}:{minutes:0>2})")
     } else {
-        format!("({:0>2}:{:0>2})", hours, minutes)
+        format!("({hours:0>2}:{minutes:0>2})")
     }
 }
 
@@ -249,13 +246,13 @@ impl Last {
             ))?;
 
         if let Some(file_time) = first_ut_time {
-            println!("\n{} begins {}", path_str, file_time);
+            println!("\n{path_str} begins {file_time}");
         } else {
             let secs = fs::metadata(&self.file)?.ctime();
             let nsecs = fs::metadata(&self.file)?.ctime_nsec() as u64;
             let file_time = self.utmp_file_time(secs, nsecs);
 
-            println!("\n{} begins {}", path_str, file_time);
+            println!("\n{path_str} begins {file_time}");
         }
 
         Ok(())

--- a/src/uu/lscpu/src/lscpu.rs
+++ b/src/uu/lscpu/src/lscpu.rs
@@ -285,7 +285,7 @@ fn print_output(infos: CpuInfos, out_opts: OutputOptions) {
 }
 
 fn find_cpuinfo_value(contents: &str, key: &str) -> Option<String> {
-    let pattern = format!(r"^{}\s+:\s+(.*)$", key);
+    let pattern = format!(r"^{key}\s+:\s+(.*)$");
     let re = RegexBuilder::new(pattern.as_str())
         .multi_line(true)
         .build()

--- a/src/uu/lscpu/src/sysfs.rs
+++ b/src/uu/lscpu/src/sysfs.rs
@@ -47,7 +47,7 @@ impl CpuTopology {
         let online_cpus = parse_cpu_list(&read_online_cpus());
 
         for cpu_index in online_cpus {
-            let cpu_dir = PathBuf::from(format!("/sys/devices/system/cpu/cpu{}/", cpu_index));
+            let cpu_dir = PathBuf::from(format!("/sys/devices/system/cpu/cpu{cpu_index}/"));
 
             let pkg_id = fs::read_to_string(cpu_dir.join("topology/physical_package_id"))
                 .unwrap()
@@ -132,7 +132,7 @@ impl CacheSize {
             _ => return format!("{} bytes", self.0),
         };
         let scaled_size = self.0 / denominator;
-        format!("{} {}", scaled_size, unit)
+        format!("{scaled_size} {unit}")
     }
 }
 
@@ -145,7 +145,7 @@ pub fn read_online_cpus() -> String {
 }
 
 fn read_cpu_caches(cpu_index: usize) -> Vec<CpuCache> {
-    let cpu_dir = PathBuf::from(format!("/sys/devices/system/cpu/cpu{}/", cpu_index));
+    let cpu_dir = PathBuf::from(format!("/sys/devices/system/cpu/cpu{cpu_index}/"));
     let cache_dir = fs::read_dir(cpu_dir.join("cache")).unwrap();
     let cache_paths = cache_dir
         .flatten()
@@ -161,7 +161,7 @@ fn read_cpu_caches(cpu_index: usize) -> Vec<CpuCache> {
             "Unified" => CacheType::Unified,
             "Data" => CacheType::Data,
             "Instruction" => CacheType::Instruction,
-            _ => panic!("Unrecognized cache type: {}", type_string),
+            _ => panic!("Unrecognized cache type: {type_string}"),
         };
 
         let c_level = fs::read_to_string(cache_path.join("level"))
@@ -225,7 +225,7 @@ pub fn read_cpu_byte_order() -> Option<&'static str> {
         match byte_order.trim() {
             "big" => return Some("Big Endian"),
             "little" => return Some("Little Endian"),
-            _ => eprintln!("Unrecognised Byte Order: {}", byte_order),
+            _ => eprintln!("Unrecognised Byte Order: {byte_order}"),
         }
     }
     None

--- a/src/uu/lsmem/src/lsmem.rs
+++ b/src/uu/lsmem/src/lsmem.rs
@@ -156,7 +156,7 @@ enum ZoneId {
 impl core::fmt::Display for ZoneId {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         let value = serde_json::to_string(self).unwrap().replace("\"", "");
-        write!(f, "{}", value)
+        write!(f, "{value}")
     }
 }
 

--- a/src/uu/lsmem/src/utils.rs
+++ b/src/uu/lsmem/src/utils.rs
@@ -40,7 +40,7 @@ pub fn size_to_human_string(bytes: u64) -> String {
     // Format the result
     if frac != 0 {
         let decimal_point = ".";
-        buf = format!("{}{}{:02}", dec, decimal_point, frac);
+        buf = format!("{dec}{decimal_point}{frac:02}");
         if buf.ends_with('0') {
             buf.pop(); // Remove extraneous zero
         }

--- a/src/uu/mcookie/src/mcookie.rs
+++ b/src/uu/mcookie/src/mcookie.rs
@@ -98,17 +98,17 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
     hasher.update(rand_bytes);
 
     if verbose {
-        eprintln!("Got {} bytes from randomness source", RANDOM_BYTES);
+        eprintln!("Got {RANDOM_BYTES} bytes from randomness source");
     }
 
     let result = hasher.finalize();
     let output = result
         .iter()
-        .map(|byte| format!("{:02x}", byte))
+        .map(|byte| format!("{byte:02x}"))
         .collect::<Vec<_>>()
         .join("");
 
-    println!("{}", output);
+    println!("{output}");
 
     Ok(())
 }

--- a/src/uu/mountpoint/src/mountpoint.rs
+++ b/src/uu/mountpoint/src/mountpoint.rs
@@ -23,9 +23,9 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
 
     if let Some(path) = path {
         if is_mountpoint(path) {
-            println!("{} is a mountpoint", path);
+            println!("{path} is a mountpoint");
         } else {
-            println!("{} is not a mountpoint", path);
+            println!("{path} is not a mountpoint");
         }
     } else {
         // Handle the case where path is not provided

--- a/src/uu/renice/src/renice.rs
+++ b/src/uu/renice/src/renice.rs
@@ -38,7 +38,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         process::exit(1);
     }
 
-    println!("Nice value of process {} set to {}", pid, nice_value);
+    println!("Nice value of process {pid} set to {nice_value}");
     Ok(())
 }
 

--- a/src/uu/uuidgen/src/uuidgen.rs
+++ b/src/uu/uuidgen/src/uuidgen.rs
@@ -134,7 +134,7 @@ fn namespace_from_str(s: &str) -> Result<Uuid, USimpleError> {
         "@x500" => Ok(Uuid::NAMESPACE_X500),
         _ => Err(USimpleError {
             code: 1,
-            message: format!("Invalid namespace {}.", s),
+            message: format!("Invalid namespace {s}."),
         }),
     }
 }

--- a/tests/by-util/test_lsmem.rs
+++ b/tests/by-util/test_lsmem.rs
@@ -47,7 +47,7 @@ impl TestSysMemory {
         write_file_content(&sysmem, "block_size_bytes", "8000000\n");
 
         for i in MEMORY_BLOCK_IDS {
-            let block_dir = sysmem.join(format!("memory{}", i));
+            let block_dir = sysmem.join(format!("memory{i}"));
             write_file_content(&block_dir, "removable", "1\n");
             write_file_content(&block_dir, "state", "online\n");
             let valid_zone = match i {

--- a/tests/by-util/test_mcookie.rs
+++ b/tests/by-util/test_mcookie.rs
@@ -169,7 +169,7 @@ fn test_not_existing_file() {
         file1.path().to_str().unwrap()
     ));
 
-    res.stderr_contains(format!("mcookie: cannot open {}", file_not_existing));
+    res.stderr_contains(format!("mcookie: cannot open {file_not_existing}"));
 
     // Ensure we only read up to the limit of bytes, despite the file being bigger
     res.stderr_contains(format!(

--- a/tests/common/util.rs
+++ b/tests/common/util.rs
@@ -1440,7 +1440,7 @@ impl UCommand {
             // Input/output error (os error 5) is returned due to pipe closes. Buffer gets content anyway.
             Err(e) if e.raw_os_error().unwrap_or_default() == 5 => {}
             Err(e) => {
-                eprintln!("Unexpected error: {:?}", e);
+                eprintln!("Unexpected error: {e:?}");
                 panic!("error forwarding output of pty");
             }
         }
@@ -3675,7 +3675,7 @@ mod tests {
 
         std::assert_eq!(
             String::from_utf8_lossy(out.stdout()),
-            format!("{}\r\n", message)
+            format!("{message}\r\n")
         );
         std::assert_eq!(String::from_utf8_lossy(out.stderr()), "");
     }


### PR DESCRIPTION
This PR fixes warnings from the [uninlined_format_args](https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args) lints.