### PR TITLE
Bump `linux-raw-sys` from `0.9.0` to `0.10.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,7 +526,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -551,6 +551,12 @@ name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13d6a630ed4f43c11056af8768c4773df2c43bc780b6d8a46de345c17236c562"
 
 [[package]]
 name = "log"
@@ -1304,7 +1310,7 @@ name = "uu_blockdev"
 version = "0.0.1"
 dependencies = [
  "clap",
- "linux-raw-sys 0.9.4",
+ "linux-raw-sys 0.10.0",
  "regex",
  "sysinfo",
  "uucore",
@@ -1348,7 +1354,7 @@ name = "uu_fsfreeze"
 version = "0.0.1"
 dependencies = [
  "clap",
- "linux-raw-sys 0.9.4",
+ "linux-raw-sys 0.10.0",
  "regex",
  "sysinfo",
  "uucore",
@@ -1650,7 +1656,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ dns-lookup = "2.0.4"
 errno = "0.3"
 libc = "0.2.171"
 libmount-sys = "0.1.1"
-linux-raw-sys = { version = "0.9.0", features = ["ioctl"] }
+linux-raw-sys = { version = "0.10.0", features = ["ioctl"] }
 md-5 = "0.10.6"
 nix = { version = "0.30", default-features = false }
 phf = "0.12.0"


### PR DESCRIPTION
This PR manually bumps `linux-raw-sys` from `0.9.0` to `0.10.0` because renovate fails with an "Artifact update problem" in https://github.com/uutils/util-linux/pull/331.