### PR TITLE
dmesg: use `parse_datetime` from workspace

### DIFF
--- a/src/uu/dmesg/Cargo.toml
+++ b/src/uu/dmesg/Cargo.toml
@@ -11,13 +11,13 @@ name = "dmesg"
 path = "src/main.rs"
 
 [dependencies]
-clap = { workspace = true }
-uucore = { workspace = true }
-regex = { workspace = true }
-serde_json = { workspace = true }
-serde = { workspace = true }
 chrono = "0.4.38"
+clap = { workspace = true }
 parse_datetime = { workspace = true }
+regex = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+uucore = { workspace = true }
 
 [features]
 fixed-boot-time = []

--- a/src/uu/dmesg/Cargo.toml
+++ b/src/uu/dmesg/Cargo.toml
@@ -17,7 +17,7 @@ regex = { workspace = true }
 serde_json = { workspace = true }
 serde = { workspace = true }
 chrono = "0.4.38"
-parse_datetime = "0.11.0"
+parse_datetime = { workspace = true }
 
 [features]
 fixed-boot-time = []


### PR DESCRIPTION
This PR uses `parse_datetime` from workspace and sorts the dependency entries in `Cargo.toml` alphabetically.