### PR TITLE
tests: remove unused imports

### DIFF
--- a/tests/by-util/test_blockdev.rs
+++ b/tests/by-util/test_blockdev.rs
@@ -4,8 +4,6 @@
 // file that was distributed with this source code.
 
 use uutests::new_ucmd;
-use uutests::util::TestScenario;
-use uutests::util_name;
 
 #[test]
 fn test_invalid_arg() {
@@ -28,8 +26,6 @@ mod linux {
     use regex::Regex;
 
     use uutests::new_ucmd;
-    use uutests::util::TestScenario;
-    use uutests::util_name;
 
     #[test]
     fn test_fails_on_first_error() {
@@ -62,8 +58,6 @@ mod linux {
 #[cfg(not(target_os = "linux"))]
 mod non_linux {
     use uutests::new_ucmd;
-    use uutests::util::TestScenario;
-    use uutests::util_name;
 
     #[test]
     fn test_fails_on_unsupported_platforms() {

--- a/tests/by-util/test_ctrlaltdel.rs
+++ b/tests/by-util/test_ctrlaltdel.rs
@@ -5,10 +5,6 @@
 
 #[cfg(target_os = "linux")]
 use uutests::new_ucmd;
-#[cfg(target_os = "linux")]
-use uutests::util::TestScenario;
-#[cfg(target_os = "linux")]
-use uutests::util_name;
 
 #[test]
 #[cfg(target_os = "linux")]

--- a/tests/by-util/test_dmesg.rs
+++ b/tests/by-util/test_dmesg.rs
@@ -4,8 +4,6 @@
 // file that was distributed with this source code.
 
 use uutests::new_ucmd;
-use uutests::util::TestScenario;
-use uutests::util_name;
 
 #[test]
 fn test_invalid_arg() {

--- a/tests/by-util/test_fsfreeze.rs
+++ b/tests/by-util/test_fsfreeze.rs
@@ -4,8 +4,6 @@
 // file that was distributed with this source code.
 
 use uutests::new_ucmd;
-use uutests::util::TestScenario;
-use uutests::util_name;
 
 #[test]
 fn test_invalid_arg() {
@@ -27,8 +25,6 @@ fn test_operations_mutually_exclusive() {
 mod linux {
 
     use uutests::new_ucmd;
-    use uutests::util::TestScenario;
-    use uutests::util_name;
 
     #[test]
     fn test_fails_on_non_existing_path() {
@@ -54,8 +50,6 @@ mod linux {
 #[cfg(not(target_os = "linux"))]
 mod non_linux {
     use uutests::new_ucmd;
-    use uutests::util::TestScenario;
-    use uutests::util_name;
 
     #[test]
     fn test_fails_on_unsupported_platforms() {

--- a/tests/by-util/test_lscpu.rs
+++ b/tests/by-util/test_lscpu.rs
@@ -4,8 +4,6 @@
 // file that was distributed with this source code.
 
 use uutests::new_ucmd;
-use uutests::util::TestScenario;
-use uutests::util_name;
 
 #[test]
 fn test_invalid_arg() {

--- a/tests/by-util/test_lslocks.rs
+++ b/tests/by-util/test_lslocks.rs
@@ -5,10 +5,6 @@
 
 #[cfg(target_os = "linux")]
 use uutests::new_ucmd;
-#[cfg(target_os = "linux")]
-use uutests::util::TestScenario;
-#[cfg(target_os = "linux")]
-use uutests::util_name;
 
 #[test]
 #[cfg(target_os = "linux")]

--- a/tests/by-util/test_lsmem.rs
+++ b/tests/by-util/test_lsmem.rs
@@ -5,8 +5,6 @@
 
 use std::path::Path;
 use uutests::new_ucmd;
-use uutests::util::TestScenario;
-use uutests::util_name;
 
 fn write_file_content(dir: &Path, name: &str, content: &str) {
     std::fs::create_dir_all(dir).unwrap();

--- a/tests/by-util/test_mcookie.rs
+++ b/tests/by-util/test_mcookie.rs
@@ -8,8 +8,6 @@ use std::io::Write;
 use tempfile::NamedTempFile;
 
 use uutests::new_ucmd;
-use uutests::util::TestScenario;
-use uutests::util_name;
 
 #[test]
 fn test_invalid_arg() {

--- a/tests/by-util/test_mesg.rs
+++ b/tests/by-util/test_mesg.rs
@@ -4,8 +4,6 @@
 // file that was distributed with this source code.
 
 use uutests::new_ucmd;
-use uutests::util::TestScenario;
-use uutests::util_name;
 
 #[test]
 fn test_invalid_verb() {
@@ -27,8 +25,6 @@ fn test_no_terminal() {
 #[cfg(not(target_family = "unix"))]
 mod non_unix {
     use uutests::new_ucmd;
-    use uutests::util::TestScenario;
-    use uutests::util_name;
 
     #[test]
     fn test_fails_on_unsupported_platforms() {

--- a/tests/by-util/test_mountpoint.rs
+++ b/tests/by-util/test_mountpoint.rs
@@ -4,8 +4,7 @@
 // file that was distributed with this source code.
 
 use uutests::new_ucmd;
-use uutests::util::TestScenario;
-use uutests::util_name;
+
 #[test]
 fn test_invalid_arg() {
     new_ucmd!().arg("--definitely-invalid").fails().code_is(1);

--- a/tests/by-util/test_nologin.rs
+++ b/tests/by-util/test_nologin.rs
@@ -3,7 +3,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-use uutests::{new_ucmd, util::TestScenario, util_name};
+use uutests::new_ucmd;
 
 #[test]
 fn test_invalid_arg() {

--- a/tests/by-util/test_renice.rs
+++ b/tests/by-util/test_renice.rs
@@ -5,8 +5,6 @@
 // spell-checker:ignore (words) symdir somefakedir
 
 use uutests::new_ucmd;
-use uutests::util::TestScenario;
-use uutests::util_name;
 
 #[test]
 fn test_invalid_arg() {

--- a/tests/by-util/test_rev.rs
+++ b/tests/by-util/test_rev.rs
@@ -3,10 +3,7 @@
 // For the full copyright and license information, please view the LICENSE
 // file that was distributed with this source code.
 
-use uutests::at_and_ucmd;
-use uutests::new_ucmd;
-use uutests::util::TestScenario;
-use uutests::util_name;
+use uutests::{at_and_ucmd, new_ucmd};
 
 #[test]
 fn test_invalid_arg() {

--- a/tests/by-util/test_setsid.rs
+++ b/tests/by-util/test_setsid.rs
@@ -7,9 +7,8 @@
 mod unix {
     use uutests::new_ucmd;
     use uutests::util::get_tests_binary;
-    use uutests::util::TestScenario;
     use uutests::util::UCommand;
-    use uutests::util_name;
+
     #[test]
     fn test_invalid_arg() {
         new_ucmd!().arg("--definitely-invalid").fails().code_is(1);
@@ -170,8 +169,6 @@ mod unix {
 #[cfg(not(target_family = "unix"))]
 mod non_unix {
     use uutests::new_ucmd;
-    use uutests::util::TestScenario;
-    use uutests::util_name;
 
     #[test]
     fn unsupported_platforms() {

--- a/tests/by-util/test_uuidgen.rs
+++ b/tests/by-util/test_uuidgen.rs
@@ -4,7 +4,7 @@
 // file that was distributed with this source code.
 
 use uuid::Uuid;
-use uutests::{new_ucmd, util::TestScenario, util::UCommand, util_name};
+use uutests::{new_ucmd, util::UCommand};
 
 fn assert_ver_eq(cmd: &mut UCommand, ver: uuid::Version) {
     let uuid = Uuid::parse_str(


### PR DESCRIPTION
This PR removes unused imports that are no longer needed after the update of `uutests`.