### PR TITLE
Bump `uucore` & adapt `last` to API change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,18 +330,6 @@ dependencies = [
 
 [[package]]
 name = "dns-lookup"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf5597a4b7fe5275fc9dcf88ce26326bc8e4cb87d0130f33752d4c5f717793cf"
-dependencies = [
- "cfg-if",
- "libc",
- "socket2",
- "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "dns-lookup"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "853d5bcf0b73bd5e6d945b976288621825c7166e9f06c5a035ae1aaf42d1b64f"
@@ -1338,7 +1326,7 @@ dependencies = [
  "clap_complete",
  "clap_mangen",
  "ctor 0.4.3",
- "dns-lookup 3.0.0",
+ "dns-lookup",
  "libc",
  "nix",
  "parse_datetime",
@@ -1370,7 +1358,7 @@ dependencies = [
  "uu_rev",
  "uu_setsid",
  "uu_uuidgen",
- "uucore 0.1.0",
+ "uucore",
  "uuid",
  "uutests",
  "xattr",
@@ -1384,7 +1372,7 @@ dependencies = [
  "linux-raw-sys 0.11.0",
  "regex",
  "sysinfo",
- "uucore 0.1.0",
+ "uucore",
 ]
 
 [[package]]
@@ -1396,7 +1384,7 @@ dependencies = [
  "rangemap",
  "syscall-numbers",
  "thiserror",
- "uucore 0.1.0",
+ "uucore",
 ]
 
 [[package]]
@@ -1404,7 +1392,7 @@ name = "uu_ctrlaltdel"
 version = "0.0.1"
 dependencies = [
  "clap",
- "uucore 0.1.0",
+ "uucore",
 ]
 
 [[package]]
@@ -1417,7 +1405,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "uucore 0.1.0",
+ "uucore",
 ]
 
 [[package]]
@@ -1428,7 +1416,7 @@ dependencies = [
  "linux-raw-sys 0.11.0",
  "regex",
  "sysinfo",
- "uucore 0.1.0",
+ "uucore",
 ]
 
 [[package]]
@@ -1436,9 +1424,9 @@ name = "uu_last"
 version = "0.0.1"
 dependencies = [
  "clap",
- "dns-lookup 3.0.0",
+ "dns-lookup",
  "parse_datetime",
- "uucore 0.1.0",
+ "uucore",
 ]
 
 [[package]]
@@ -1450,7 +1438,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sysinfo",
- "uucore 0.1.0",
+ "uucore",
 ]
 
 [[package]]
@@ -1461,7 +1449,7 @@ dependencies = [
  "errno",
  "libc",
  "smartcols-sys",
- "uucore 0.1.0",
+ "uucore",
 ]
 
 [[package]]
@@ -1472,7 +1460,7 @@ dependencies = [
  "libc",
  "libmount-sys",
  "smartcols-sys",
- "uucore 0.1.0",
+ "uucore",
 ]
 
 [[package]]
@@ -1482,7 +1470,7 @@ dependencies = [
  "clap",
  "serde",
  "serde_json",
- "uucore 0.1.0",
+ "uucore",
 ]
 
 [[package]]
@@ -1492,7 +1480,7 @@ dependencies = [
  "clap",
  "md-5",
  "rand",
- "uucore 0.1.0",
+ "uucore",
 ]
 
 [[package]]
@@ -1501,7 +1489,7 @@ version = "0.0.1"
 dependencies = [
  "clap",
  "nix",
- "uucore 0.1.0",
+ "uucore",
 ]
 
 [[package]]
@@ -1509,7 +1497,7 @@ name = "uu_mountpoint"
 version = "0.0.1"
 dependencies = [
  "clap",
- "uucore 0.1.0",
+ "uucore",
 ]
 
 [[package]]
@@ -1517,7 +1505,7 @@ name = "uu_nologin"
 version = "0.0.1"
 dependencies = [
  "clap",
- "uucore 0.1.0",
+ "uucore",
 ]
 
 [[package]]
@@ -1526,7 +1514,7 @@ version = "0.0.1"
 dependencies = [
  "clap",
  "libc",
- "uucore 0.1.0",
+ "uucore",
 ]
 
 [[package]]
@@ -1534,7 +1522,7 @@ name = "uu_rev"
 version = "0.0.1"
 dependencies = [
  "clap",
- "uucore 0.1.0",
+ "uucore",
 ]
 
 [[package]]
@@ -1543,7 +1531,7 @@ version = "0.0.1"
 dependencies = [
  "clap",
  "libc",
- "uucore 0.1.0",
+ "uucore",
 ]
 
 [[package]]
@@ -1554,30 +1542,9 @@ dependencies = [
  "nix",
  "rand",
  "thiserror",
- "uucore 0.1.0",
+ "uucore",
  "uuid",
  "windows",
-]
-
-[[package]]
-name = "uucore"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9032bf981784f22fcc5ddc7e74b7cf3bae3d5f44a48d2054138ed38068b9f4e0"
-dependencies = [
- "clap",
- "dns-lookup 2.1.1",
- "fluent",
- "fluent-bundle",
- "libc",
- "nix",
- "number_prefix",
- "os_display",
- "thiserror",
- "time",
- "unic-langid",
- "uucore_procs 0.1.0",
- "wild",
 ]
 
 [[package]]
@@ -1588,7 +1555,7 @@ checksum = "7203e48e80ac344450cba5323d8b4a71967ec1e81ae4022775ada90d2b0e08ac"
 dependencies = [
  "bstr",
  "clap",
- "dns-lookup 3.0.0",
+ "dns-lookup",
  "fluent",
  "fluent-bundle",
  "fluent-syntax",
@@ -1600,19 +1567,8 @@ dependencies = [
  "thiserror",
  "time",
  "unic-langid",
- "uucore_procs 0.2.2",
+ "uucore_procs",
  "wild",
-]
-
-[[package]]
-name = "uucore_procs"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c933945fdac5b7779eae1fc746146e61f5b0298deb6ede002ce0b6e93e1b3bfc"
-dependencies = [
- "proc-macro2",
- "quote",
- "uuhelp_parser 0.1.0",
 ]
 
 [[package]]
@@ -1623,14 +1579,8 @@ checksum = "449e64ce116ed0cc8c5897bd8706d36aed1ec027b647494df4eae6996d8d59de"
 dependencies = [
  "proc-macro2",
  "quote",
- "uuhelp_parser 0.2.2",
+ "uuhelp_parser",
 ]
-
-[[package]]
-name = "uuhelp_parser"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beda381dd5c7927f8682f50b055b0903bb694ba5a4b27fad1b4934bc4fbf7b8d"
 
 [[package]]
 name = "uuhelp_parser"
@@ -1677,7 +1627,7 @@ dependencies = [
  "regex",
  "rlimit",
  "tempfile",
- "uucore 0.2.2",
+ "uucore",
  "xattr",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ sysinfo = "0.37"
 tempfile = "3.9.0"
 textwrap = { version = "0.16.0", features = ["terminal_size"] }
 thiserror = "2.0"
-uucore = "0.1.0"
+uucore = "0.2.2"
 uuid = { version = "1.16.0", features = ["rng-rand"] }
 uutests = "0.2.0"
 windows = { version = "0.61.1" }

--- a/src/uu/last/src/platform/unix.rs
+++ b/src/uu/last/src/platform/unix.rs
@@ -11,7 +11,7 @@ use uucore::error::UResult;
 
 use uucore::error::USimpleError;
 use uucore::utmpx::time::{OffsetDateTime, UtcOffset};
-use uucore::utmpx::{time, Utmpx};
+use uucore::utmpx::{time, Utmpx, UtmpxRecord};
 
 use std::fmt::Write;
 use std::fs;
@@ -217,7 +217,10 @@ impl Last {
         // For 'last' output, older output needs to be printed last (FILO), as
         // UtmpxIter does not implement Rev trait. A better implementation
         // might include implementing UtmpxIter as doubly linked
-        Utmpx::iter_all_records_from(&self.file).for_each(|ut| ut_stack.push(ut));
+        Utmpx::iter_all_records_from(&self.file).for_each(|ut| {
+            let UtmpxRecord::Traditional(utmpx) = ut;
+            ut_stack.push(*utmpx);
+        });
 
         let mut counter = 0;
         let mut first_ut_time = None;


### PR DESCRIPTION
This PR bumps `uucore` from `0.1.0` to `0.2.2` and adapts `last` to an API change in `uucore::utmpx`.