### PR TITLE
Bump `ctor` from `0.5.0` to `0.6.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,7 +272,17 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67773048316103656a637612c4a62477603b777d91d9c62ff2290f9cde178fdb"
 dependencies = [
- "ctor-proc-macro",
+ "ctor-proc-macro 0.0.6",
+ "dtor",
+]
+
+[[package]]
+name = "ctor"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59c9b8bdf64ee849747c1b12eb861d21aa47fa161564f48332f1afe2373bf899"
+dependencies = [
+ "ctor-proc-macro 0.0.7",
  "dtor",
 ]
 
@@ -281,6 +291,12 @@ name = "ctor-proc-macro"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "deranged"
@@ -1300,7 +1316,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "clap_mangen",
- "ctor",
+ "ctor 0.6.0",
  "dns-lookup",
  "libc",
  "nix",
@@ -1615,7 +1631,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20482dada0c118dfe1eafe971195c170c4e9ab5a2409ead9b9b1833f7a54b1d2"
 dependencies = [
- "ctor",
+ "ctor 0.5.0",
  "libc",
  "nix",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ setsid = { optional = true, version = "0.0.1", package = "uu_setsid", path ="src
 uuidgen = { optional = true, version = "0.0.1", package = "uu_uuidgen", path ="src/uu/uuidgen" }
 
 [dev-dependencies]
-ctor = "0.5.0"
+ctor = "0.6.0"
 # dmesg test require fixed-boot-time feature turned on.
 dmesg = { version = "0.0.1", package = "uu_dmesg", path = "src/uu/dmesg", features = ["fixed-boot-time"] }
 libc = { workspace = true }


### PR DESCRIPTION
This PR manually bumps `ctor` from `0.5.0` to `0.6.0` because renovate fails with an "Artifact update problem" in https://github.com/uutils/util-linux/pull/409.