### PR TITLE
clippy: fix warnings from `useless_vec` lint

### DIFF
--- a/tests/by-util/test_cal.rs
+++ b/tests/by-util/test_cal.rs
@@ -19,7 +19,7 @@ fn test_invalid_dates() {
 
 #[test]
 fn test_iso_week_numbers() {
-    let expected = vec![
+    let expected = [
         "     January 2021      \n",
         "   Mo Tu We Th Fr Sa Su\n",
         "53              1  2  3\n",
@@ -34,7 +34,7 @@ fn test_iso_week_numbers() {
         .succeeds()
         .stdout_is(expected.join(""));
 
-    let expected = vec![
+    let expected = [
         "     January 2015      \n",
         "   Mo Tu We Th Fr Sa Su\n",
         " 1           1  2  3  4\n",
@@ -52,7 +52,7 @@ fn test_iso_week_numbers() {
 
 #[test]
 fn test_us_week_numbers() {
-    let expected = vec![
+    let expected = [
         "     January 2021      \n",
         "   Su Mo Tu We Th Fr Sa\n",
         " 1                 1  2\n",
@@ -70,7 +70,7 @@ fn test_us_week_numbers() {
 
 #[test]
 fn test_julian() {
-    let expected = vec![
+    let expected = [
         "       December 2000       \n",
         "Sun Mon Tue Wed Thu Fri Sat\n",
         "                    336 337\n",
@@ -85,7 +85,7 @@ fn test_julian() {
         .succeeds()
         .stdout_is(expected.join(""));
 
-    let expected = vec![
+    let expected = [
         "        February 2024         \n",
         "   Mon Tue Wed Thu Fri Sat Sun\n",
         " 5              32  33  34  35\n",
@@ -162,7 +162,7 @@ fn test_zero_months_displays_one() {
 
 #[test]
 fn test_color() {
-    let expected = vec![
+    let expected = [
         "     March 2024     \n",
         "Su Mo Tu We Th Fr Sa\n",
         "                1  2\n",
@@ -177,7 +177,7 @@ fn test_color() {
         .succeeds()
         .stdout_is(expected.join(""));
 
-    let expected = vec![
+    let expected = [
         "     March 2024     \n",
         "Su Mo Tu We Th Fr Sa\n",
         "                1  2\n",

--- a/tests/by-util/test_hexdump.rs
+++ b/tests/by-util/test_hexdump.rs
@@ -46,7 +46,7 @@ fn test_hexdump_canonical_format() {
 #[cfg(unix)]
 fn test_hexdump_one_byte_char() {
     let input = b"Hello \t\n\0\x07\x08\x0B\x0C\r\x80\xFF";
-    let expected = vec![
+    let expected = [
         "0000000   H   e   l   l   o      \\t  \\n  \\0  \\a  \\b  \\v  \\f  \\r 200 377\n",
         "0000010\n",
     ];
@@ -113,7 +113,7 @@ fn test_hexdump_two_bytes_octal() {
 #[test]
 #[cfg(unix)]
 fn test_hexdump_multiple_formats() {
-    let expected = vec![
+    let expected = [
         "00000000  41 42                                             |AB|\n",
         "0000000    4241                                                        \n",
         "00000000  41 42                                             |AB|\n",
@@ -130,21 +130,21 @@ fn test_hexdump_multiple_formats() {
 #[test]
 #[cfg(unix)]
 fn test_hexdump_squeezing() {
-    let input = vec![
+    let input = [
         "AAAAAAAAAAAAAAAA",
         "AAAAAAAAAAAAAAAA",
         "AAAAAAAAAAAAAAAA",
         "AAAAAAAA",
     ];
 
-    let expected_no_squeezing = vec![
+    let expected_no_squeezing = [
         "00000000  41 41 41 41 41 41 41 41  41 41 41 41 41 41 41 41  |AAAAAAAAAAAAAAAA|\n",
         "00000010  41 41 41 41 41 41 41 41  41 41 41 41 41 41 41 41  |AAAAAAAAAAAAAAAA|\n",
         "00000020  41 41 41 41 41 41 41 41  41 41 41 41 41 41 41 41  |AAAAAAAAAAAAAAAA|\n",
         "00000030  41 41 41 41 41 41 41 41                           |AAAAAAAA|\n",
         "00000038\n",
     ];
-    let expected_with_squeezing = vec![
+    let expected_with_squeezing = [
         "00000000  41 41 41 41 41 41 41 41  41 41 41 41 41 41 41 41  |AAAAAAAAAAAAAAAA|\n",
         "*\n",
         "00000030  41 41 41 41 41 41 41 41                           |AAAAAAAA|\n",


### PR DESCRIPTION
This PR fixes some warnings from the [useless_vec](https://rust-lang.github.io/rust-clippy/stable/index.html#useless_vec) lint that show up after upgrading to Rust `1.91.0`.