### PR TITLE
Bump `nix` from `0.30` to `0.31`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,6 +708,18 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225e7cfe711e0ba79a68baeddb2982723e4235247aefce1482f2f16c27865b66"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
  "memoffset",
 ]
 
@@ -1364,7 +1376,7 @@ dependencies = [
  "ctor",
  "dns-lookup",
  "libc",
- "nix",
+ "nix 0.31.1",
  "parse_datetime",
  "phf",
  "phf_codegen",
@@ -1544,7 +1556,7 @@ name = "uu_mesg"
 version = "0.0.1"
 dependencies = [
  "clap",
- "nix",
+ "nix 0.31.1",
  "uucore 0.2.2",
 ]
 
@@ -1587,7 +1599,7 @@ version = "0.0.1"
 dependencies = [
  "clap",
  "libc",
- "nix",
+ "nix 0.31.1",
  "uucore 0.2.2",
 ]
 
@@ -1605,7 +1617,7 @@ name = "uu_uuidgen"
 version = "0.0.1"
 dependencies = [
  "clap",
- "nix",
+ "nix 0.31.1",
  "rand",
  "thiserror",
  "uucore 0.2.2",
@@ -1629,7 +1641,7 @@ dependencies = [
  "glob",
  "jiff",
  "libc",
- "nix",
+ "nix 0.30.1",
  "num-traits",
  "number_prefix",
  "os_display",
@@ -1653,7 +1665,7 @@ dependencies = [
  "fluent-syntax",
  "jiff",
  "libc",
- "nix",
+ "nix 0.30.1",
  "os_display",
  "thiserror",
  "time",
@@ -1722,7 +1734,7 @@ checksum = "83559c0581b560419248e130b8d8a3d362ae1f4d0a150ac5c493cc0acdb1ae31"
 dependencies = [
  "ctor",
  "libc",
- "nix",
+ "nix 0.30.1",
  "pretty_assertions",
  "rand",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ libc = "0.2.171"
 libmount-sys = "0.1.1"
 linux-raw-sys = { version = "0.12.0", features = ["ioctl"] }
 md-5 = "0.10.6"
-nix = { version = "0.30", default-features = false }
+nix = { version = "0.31", default-features = false }
 parse_datetime = "0.11.0"
 phf = "0.13.0"
 phf_codegen = "0.13.0"


### PR DESCRIPTION
This PR manually bumps `nix` from `0.30` to `0.31` because renovate fails with an "Artifact update problem" in https://github.com/uutils/util-linux/pull/463