### PR TITLE
Bump `rlimit` from `0.10.1` to `0.11.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,6 +1012,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rlimit"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f35ee2729c56bb610f6dba436bf78135f728b7373bdffae2ec815b2d3eb98cc3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "roff"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1362,7 +1371,7 @@ dependencies = [
  "pretty_assertions",
  "rand",
  "regex",
- "rlimit",
+ "rlimit 0.11.0",
  "serde",
  "serde_json",
  "tempfile",
@@ -1718,7 +1727,7 @@ dependencies = [
  "pretty_assertions",
  "rand",
  "regex",
- "rlimit",
+ "rlimit 0.10.2",
  "tempfile",
  "uucore 0.5.0",
  "xattr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,7 @@ nix = { workspace = true, features = ["term"] }
 xattr = { workspace = true }
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dev-dependencies]
-rlimit = "0.10.1"
+rlimit = "0.11.0"
 
 [build-dependencies]
 phf_codegen = { workspace = true }


### PR DESCRIPTION
This PR manually bumps `rlimit` from `0.10.1` to `0.11.0` because renovate fails with an "Artifact update problem" in https://github.com/uutils/util-linux/pull/469