### PR TITLE
Cargo.toml: bump Rust version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/uutils/util-linux"
 readme = "README.md"
 keywords = ["util-linux", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-rust-version = "1.70.0"
+rust-version = "1.94.0"
 edition = "2021"
 
 build = "build.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ repository = "https://github.com/uutils/util-linux"
 readme = "README.md"
 keywords = ["util-linux", "uutils", "cross-platform", "cli", "utility"]
 categories = ["command-line-utilities"]
-rust-version = "1.70.0"
-edition = "2021"
+rust-version = "1.98.1"
+edition = "2024"
 
 build = "build.rs"
 


### PR DESCRIPTION
No reason to restrict toolcain and build time for WIP project.