### PR TITLE
Bump `ctor` & adapt to change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,9 +362,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.12.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8f521dd9c9e5f03986eb5c674b14b21e9ccf2eb9f98fecb681100214d5e9e4f"
+checksum = "f7335955a5f85f95f3188623240e081e7b2059a8ad1bae68944b7cfdd718fb10"
 dependencies = [
  "link-section",
  "linktime-proc-macro",
@@ -775,9 +775,9 @@ dependencies = [
 
 [[package]]
 name = "link-section"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0567ec9fe5ffdf9241cd90a7629f250a5f903d6ff4573cf7903308662d6fce40"
+checksum = "ea2c24837c4fd5ab6a31d64133eae954f5199247523cf29586117e85245c0dd3"
 
 [[package]]
 name = "linktime-proc-macro"
@@ -1502,7 +1502,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "clap_mangen",
- "ctor 0.12.0",
+ "ctor 1.0.1",
  "dns-lookup",
  "libc",
  "nix 0.31.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ setsid = { optional = true, version = "0.0.1", package = "uu_setsid", path ="src
 uuidgen = { optional = true, version = "0.0.1", package = "uu_uuidgen", path ="src/uu/uuidgen" }
 
 [dev-dependencies]
-ctor = "0.12.0"
+ctor = "1.0.0"
 # dmesg test require fixed-boot-time feature turned on.
 dmesg = { version = "0.0.1", package = "uu_dmesg", path = "src/uu/dmesg", features = ["fixed-boot-time"] }
 libc = { workspace = true }
@@ -125,9 +125,9 @@ pretty_assertions = "1"
 rand = { workspace = true }
 regex = { workspace = true }
 tempfile = { workspace = true }
-uutests = { workspace = true }
 uucore = { workspace = true, features = ["entries", "process", "signals"] }
 uuid = { workspace = true }
+uutests = { workspace = true }
 
 [target.'cfg(unix)'.dev-dependencies]
 nix = { workspace = true, features = ["term"] }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -8,7 +8,7 @@ use std::env;
 pub const TESTS_BINARY: &str = env!("CARGO_BIN_EXE_util-linux");
 
 // Use the ctor attribute to run this function before any tests
-#[ctor::ctor]
+#[ctor::ctor(unsafe)]
 fn init() {
     unsafe {
         // Necessary for uutests to be able to find the binary


### PR DESCRIPTION
This PR bumps `ctor` from `0.12.0` to <del>`0.13.0`</del><del>`1.0.0`</del>`1.0.1` and adapts `tests/tests.rs` to a change in `ctor`.