### PR TITLE
ci: build generated sources in GNU util-linux befere make check-programs

### DIFF
--- a/.github/workflows/run-gnu-test.yml
+++ b/.github/workflows/run-gnu-test.yml
@@ -37,6 +37,7 @@ jobs:
           cd gnu-util-linux
           ./autogen.sh
           ./configure
+          make libsmartcols/src/filter-parser.c libsmartcols/src/filter-scanner.c
           make -j$(nproc) check-programs
       - name: Download test baseline if exists
         id: download-test-baseline


### PR DESCRIPTION
Fix "Run GNU Test CI" failure (e.g. https://github.com/uutils/util-linux/actions/runs/25803934125/job/75801282777)

```
libsmartcols/src/filter.c:25:10: fatal error: filter-parser.h: No such file or directory
   25 | #include "filter-parser.h"
      |          ^~~~~~~~~~~~~~~~~
compilation terminated.
make: *** [Makefile:12710: libsmartcols/src/la-filter.lo] Error 1
make: *** Waiting for unfinished jobs....
```

`filter-parser.h` is genereted by bison, and `filter.c` has dependency on this file. However, generated Makefile in GNU util-linux doesn't configure this dependecy. So, in the parallel build, the compiler job for `filter.c` races against bison invocation.

I added make invocation to build these autogenerated files before testsuite build.
