### PR TITLE
Add `--task` argument in `lsns`

### DIFF
--- a/src/uu/lsns/src/errors.rs
+++ b/src/uu/lsns/src/errors.rs
@@ -29,6 +29,8 @@ pub enum LsnsError {
     FailedToGetPid(String),
     /// Failed to read process information
     FailedToReadProcess(String),
+    // Invalid PID argument
+    InvalidPidArgument(String),
 }
 
 impl LsnsError {
@@ -73,6 +75,9 @@ impl fmt::Display for LsnsError {
             }
             Self::FailedToReadProcess(s) => {
                 write!(f, "Failed to read process information: {}", s)
+            }
+            Self::InvalidPidArgument(s) => {
+                write!(f, "invalid PID argument: '{}'", s)
             }
         }
     }

--- a/src/uu/lsns/src/lsns.rs
+++ b/src/uu/lsns/src/lsns.rs
@@ -87,6 +87,7 @@ struct Lsns {
     noheadings: bool,
     persistent: bool,
     namespace_type: Option<NamespaceType>,
+    task: Option<i32>,
 }
 
 #[uucore::main]
@@ -98,6 +99,14 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         .map(|s| NamespaceType::try_from(s.as_str()))
         .transpose()?;
 
+    let task = matches
+        .get_one::<String>("task")
+        .map(|s| {
+            s.parse::<i32>()
+                .map_err(|_| LsnsError::InvalidPidArgument(s.clone()))
+        })
+        .transpose()?;
+
     // Initialize lsns struct
     let mut lsns = Lsns {
         processes: Vec::new(),
@@ -105,6 +114,7 @@ pub fn uumain(args: impl uucore::Args) -> UResult<()> {
         noheadings: matches.get_flag("noheadings"),
         persistent: matches.get_flag("persistent"),
         namespace_type,
+        task,
     };
 
     read_processes(PATH_PROC, &mut lsns)?;
@@ -144,6 +154,15 @@ pub fn uu_app() -> Command {
                 .required(false)
                 .value_name("name")
                 .help("namespace type (mnt, net, ipc, user, pid, uts, cgroup, time)"),
+        )
+        .arg(
+            Arg::new("task")
+                .short('p')
+                .long("task")
+                .action(ArgAction::Set)
+                .required(false)
+                .value_name("pid")
+                .help("print process namespaces"),
         )
 }
 
@@ -561,6 +580,13 @@ fn get_table_with_columns() -> Result<Table, LsnsError> {
     Ok(table)
 }
 
+/// Check if a namespace contains a specific process
+fn namespace_has_process(lsns: &Lsns, ns: &Namespace, pid: i32) -> bool {
+    lsns.processes
+        .iter()
+        .any(|proc| proc.pid == pid && proc.ns_ids[ns.ns_type as usize] == ns.id)
+}
+
 /// Display namespaces in default format using smartcols
 #[cfg(target_os = "linux")]
 fn display_namespaces(lsns: &Lsns) -> Result<(), LsnsError> {
@@ -586,18 +612,28 @@ fn display_namespaces(lsns: &Lsns) -> Result<(), LsnsError> {
             continue;
         }
 
+        // If --type argument is supplied then show only the specified namespace type
         if let Some(namespace_type) = &lsns.namespace_type
             && ns.ns_type != *namespace_type
         {
             continue;
         }
 
-        // Get namespace type name
-        let ns_type = NSNAMES[ns.ns_type as usize];
+        // If --task argument is supplied then show only the namespaces of the specified process
+        // Note: task_pid == 0 means show all namespaces (no filtering)
+        if let Some(task_pid) = lsns.task
+            && task_pid != 0
+            && !namespace_has_process(lsns, ns, task_pid)
+        {
+            continue;
+        }
 
         // Find representative process using O(1) HashMap lookup
         let rep_pid = ns.representative_pid.unwrap_or(0);
         let rep_proc = process_map.get(&rep_pid).copied();
+
+        // Get namespace type name
+        let ns_type = NSNAMES[ns.ns_type as usize];
 
         // Get user name
         let uid = if let Some(proc) = rep_proc {

--- a/tests/by-util/test_lsns.rs
+++ b/tests/by-util/test_lsns.rs
@@ -212,3 +212,37 @@ fn test_invalid_namespace_type() {
 
     assert!(stdout.contains("lsns: unknown namespace type: invalid-namespace-type"));
 }
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_invalid_task_pid() {
+    let res = new_ucmd!().arg("--task").arg("not_a_number").fails();
+    let stderr = res.stderr_str();
+
+    assert!(stderr.contains("invalid PID argument: 'not_a_number'"));
+}
+
+// Write a test to verify that -p 0 part.
+#[test]
+#[cfg(target_os = "linux")]
+fn test_task_pid_0() {
+    let res = new_ucmd!().arg("--task").arg("0").succeeds();
+    let stdout = res.no_stderr().stdout_str();
+
+    // With -p 0, all namespaces should be shown
+    let line = stdout.lines().next().unwrap();
+
+    // Check for all regular headers
+    let columns = line.split_whitespace().count();
+    assert!(
+        columns == 6,
+        "All 6 columns should be displayed when -p 0 is used"
+    );
+
+    // Check for at least one entry
+    let entry_count = stdout.lines().count();
+    assert!(
+        entry_count > 1,
+        "There should be at least one entry when -p 0 is used"
+    );
+}


### PR DESCRIPTION
Closes https://github.com/uutils/util-linux/issues/608

This PR adds a `--task <pid>` argument to show namespaces associated with supplied PID. 

##### Option added to the CLI
```
vbmade2000@vbmade2000:~/util-linux/target/release$ ./lsns --help
List the namespaces in the system.

Usage: ./lsns [OPTION]...

Options:
  -n, --noheadings   don't print headings
  -P, --persistent   namespaces without processes
  -t, --type <name>  namespace type (mnt, net, ipc, user, pid, uts, cgroup, time)
  -p, --task <pid>   print process namespaces
  -h, --help         Print help
  -V, --version      Print version
```

##### Namespaces for the specific PID is shown with -p option.
```
vbmade2000@vbmade2000:~/Documents/projects/oss/util-linux/target/release$ ./lsns
        NS TYPE   NPROCS   PID USER       COMMAND
4026531834 time      106  2592 vbmade2000 /usr/bin/pipewire
4026531835 cgroup    106  2592 vbmade2000 /usr/bin/pipewire
4026531836 pid       105  2592 vbmade2000 /usr/bin/pipewire
4026531837 user      106  2592 vbmade2000 /usr/bin/pipewire
4026531838 uts       106  2592 vbmade2000 /usr/bin/pipewire
4026531839 ipc       106  2592 vbmade2000 /usr/bin/pipewire
4026531840 net       105  2592 vbmade2000 /usr/bin/pipewire
4026531841 mnt       103  2592 vbmade2000 /usr/bin/pipewire
4026532636 mnt         2  3719 vbmade2000 /snap/snapd-desktop-integration/391/usr/bin/user-session-helper /snap/snapd-desktop-integ
4026532637 mnt         0       root       
4026532638 mnt         1  9482 vbmade2000 /snap/firmware-updater/226/bin/firmware-notifier
4026532639 pid         1  4118 vbmade2000 /opt/zoho.com/ulaa/ulaa --type=zygote --crashpad-handler-pid=4110 --enable-crash-reporter
4026532640 net         1  4118 vbmade2000 /opt/zoho.com/ulaa/ulaa --type=zygote --crashpad-handler-pid=4110 --enable-crash-reporter
4026532820 mnt         0       root       
4026532879 mnt         0       root       
vbmade2000@vbmade2000:~/util-linux/target/release$ ./lsns -p 2592
        NS TYPE   NPROCS   PID USER       COMMAND
4026531834 time      106  2592 vbmade2000 /usr/bin/pipewire
4026531835 cgroup    106  2592 vbmade2000 /usr/bin/pipewire
4026531836 pid       105  2592 vbmade2000 /usr/bin/pipewire
4026531837 user      106  2592 vbmade2000 /usr/bin/pipewire
4026531838 uts       106  2592 vbmade2000 /usr/bin/pipewire
4026531839 ipc       106  2592 vbmade2000 /usr/bin/pipewire
4026531840 net       105  2592 vbmade2000 /usr/bin/pipewire
4026531841 mnt       103  2592 vbmade2000 /usr/bin/pipewire
myuser@mysystem:~/util-linux/target/release
```
##### Invalid PID check
```
vbmade2000@vbmade2000:~/util-linux/target/release$ ./lsns -p invalid_pid
./lsns: invalid PID argument: 'invalid_pid'
```
##### Command shows regular output (all namespaces) when using PID 0
```
vbmade2000@vbmade2000:~/Documents/projects/oss/util-linux/target/release$ ./lsns -p 0
        NS TYPE   NPROCS   PID USER       COMMAND
4026531834 time      106  2592 vbmade2000 /usr/bin/pipewire
4026531835 cgroup    106  2592 vbmade2000 /usr/bin/pipewire
4026531836 pid       105  2592 vbmade2000 /usr/bin/pipewire
4026531837 user      106  2592 vbmade2000 /usr/bin/pipewire
4026531838 uts       106  2592 vbmade2000 /usr/bin/pipewire
4026531839 ipc       106  2592 vbmade2000 /usr/bin/pipewire
4026531840 net       105  2592 vbmade2000 /usr/bin/pipewire
4026531841 mnt       103  2592 vbmade2000 /usr/bin/pipewire
4026532636 mnt         2  3719 vbmade2000 /snap/snapd-desktop-integration/391/usr/bin/user-session-helper /snap/snapd-desktop-integ
4026532637 mnt         0       root       
4026532638 mnt         1  9482 vbmade2000 /snap/firmware-updater/226/bin/firmware-notifier
4026532639 pid         1  4118 vbmade2000 /opt/zoho.com/ulaa/ulaa --type=zygote --crashpad-handler-pid=4110 --enable-crash-reporter
4026532640 net         1  4118 vbmade2000 /opt/zoho.com/ulaa/ulaa --type=zygote --crashpad-handler-pid=4110 --enable-crash-reporter
4026532820 mnt         0       root       
4026532879 mnt         0       root 
```