### PR TITLE
lscpu: fix panic when physical_package_id is -1

### DIFF
--- a/src/uu/lscpu/src/sysfs.rs
+++ b/src/uu/lscpu/src/sysfs.rs
@@ -18,7 +18,9 @@ pub struct CpuTopology {
 #[derive(Debug)]
 pub struct Cpu {
     _index: usize,
-    pub pkg_id: usize,
+    // i64 rather than usize: the kernel reports -1 when the architecture
+    // does not expose physical package information
+    pub pkg_id: i64,
     pub core_id: usize,
     pub caches: Vec<CpuCache>,
 }
@@ -53,7 +55,7 @@ impl CpuTopology {
             let pkg_id = fs::read_to_string(cpu_dir.join("topology/physical_package_id"))
                 .unwrap()
                 .trim()
-                .parse::<usize>()
+                .parse::<i64>()
                 .unwrap();
 
             let core_id = fs::read_to_string(cpu_dir.join("topology/core_id"))
@@ -274,6 +276,31 @@ fn test_print_cache_size() {
         CacheSize::new((7.6 * 1024.0 * 1024.0) as u64).human_readable(),
         "7 MiB"
     );
+}
+
+#[test]
+fn test_socket_count_with_unknown_package_id() {
+    // The kernel reports physical_package_id as -1 when the architecture does
+    // not expose package information (e.g. some ppc64 machines, see #495).
+    // All-unknown ids collapse into a single socket bucket.
+    let topology = CpuTopology {
+        cpus: vec![
+            Cpu {
+                _index: 0,
+                pkg_id: -1,
+                core_id: 0,
+                caches: vec![],
+            },
+            Cpu {
+                _index: 1,
+                pkg_id: -1,
+                core_id: 1,
+                caches: vec![],
+            },
+        ],
+    };
+    assert_eq!(topology.socket_count(), 1);
+    assert_eq!(topology.core_count(), 2);
 }
 
 #[test]


### PR DESCRIPTION
Fixes #495

`lscpu` panics with `ParseIntError { kind: InvalidDigit }` at `sysfs.rs:57` on machines where `/sys/devices/system/cpu/cpuN/topology/physical_package_id` contains `-1`.

`-1` is the kernel's documented fallback for `physical_package_id` when the architecture does not define the corresponding topology macro (observed on ppc64 in #495): https://www.kernel.org/doc/html/latest/admin-guide/cputopology.html

The code parsed the value as `usize`, so the fallback value failed to parse and the `unwrap()` panicked. This PR parses it as `i64` instead. `pkg_id` is only used for a distinct-count in `socket_count()`, so `-1` needs no special-casing: all-unknown ids collapse into a single socket bucket, which matches what util-linux `lscpu` is observed to report (`Socket(s): 1`) under the same conditions.

`core_id` is left as `usize`: the kernel's documented fallback for it is `0`, not `-1`.

**Testing**
- Reproduced the reported panic by bind-mounting a file containing `-1` over every `physical_package_id` in a mount namespace (`unshare -Urm`); after the fix the same setup exits 0 and reports `Socket(s): 1`, the same topology values util-linux `lscpu` prints there.
- Added a unit test covering `socket_count()`/`core_count()` with unknown (`-1`) package ids.
- Output on a machine with real package ids is unchanged.
