### PR TITLE
last: add [[bin]] so the binary is named last

### DIFF
--- a/src/uu/last/Cargo.toml
+++ b/src/uu/last/Cargo.toml
@@ -6,6 +6,10 @@ edition = "2021"
 [lib]
 path = "src/last.rs"
 
+[[bin]]
+name = "last"
+path = "src/main.rs"
+
 [dependencies]
 uucore = { workspace = true, features = ["utmpx"] }
 clap = { workspace = true}


### PR DESCRIPTION
Fixes #630.

`src/uu/last/Cargo.toml` declares `[lib]` but no `[[bin]]`, so cargo falls back to the package name and emits `target/release/uu_last`. `src/uu/last/src/main.rs` already exists with the usual `uucore::bin!(uu_last);`, so only the manifest section was missing.

Added it in the same shape the other utilities use (`renice`, etc.). Checked the rest of `src/uu/*` — `last` was the only one affected.

Before:
```
$ ls target/debug | grep last
libuu_last.rlib
uu_last
```
After:
```
$ ls target/debug | grep last
last
libuu_last.rlib
```

Left the missing `description` field alone; that one is repo-wide and not what the issue is about.